### PR TITLE
upgrade to opentelemetry v0.6.1

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/package.json
+++ b/packages/opentelemetry-cloud-monitoring-exporter/package.json
@@ -51,10 +51,10 @@
     "typescript": "3.7.2"
   },
   "dependencies": {
-    "@opentelemetry/api": "0.5.2",
-    "@opentelemetry/base": "0.5.2",
-    "@opentelemetry/core": "0.5.2",
-    "@opentelemetry/metrics": "0.5.2",
+    "@opentelemetry/api": "^0.6.1",
+    "@opentelemetry/base": "^0.6.1",
+    "@opentelemetry/core": "^0.6.1",
+    "@opentelemetry/metrics": "^0.6.1",
     "google-auth-library": "^5.7.0",
     "googleapis": "^46.0.0"
   }

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -126,12 +126,10 @@ function transformMetric(
   const type = transformMetricType(metricPrefix, metric.descriptor.name);
   const labels: { [key: string]: string } = {};
 
-  const labelSet = metric.labels.labels;
-
   const keys = metric.descriptor.labelKeys;
   for (let i = 0; i < keys.length; i++) {
-    if (labelSet[keys[i]] !== null) {
-      labels[keys[i]] = labelSet[keys[i]];
+    if (metric.labels[keys[i]] !== null) {
+      labels[keys[i]] = metric.labels[keys[i]];
     }
   }
   labels[OPENTELEMETRY_TASK] = OPENTELEMETRY_TASK_VALUE_DEFAULT;

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
@@ -120,11 +120,10 @@ describe('MetricExporter', () => {
     it('should export metrics', async () => {
       const meter = new MeterProvider().getMeter('test-meter');
       const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };
-      const labelSet = meter.labels(labels);
       const counter = meter.createCounter('name', {
         labelKeys: ['keya', 'keyb'],
       });
-      counter.bind(labelSet).add(10);
+      counter.bind(labels).add(10);
       meter.collect();
       const records = meter.getBatcher().checkPointSet();
 

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -147,13 +147,12 @@ describe('transform', () => {
     it('should return a Google Cloud Monitoring Metric', () => {
       const meter = new MeterProvider().getMeter('test-meter');
       const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };
-      const labelSet = meter.labels(labels);
 
       const counter = meter.createCounter(METRIC_NAME, {
         description: METRIC_DESCRIPTION,
         labelKeys: ['keya', 'keyb'],
       });
-      counter.bind(labelSet).add(10);
+      counter.bind(labels).add(10);
       meter.collect();
       const [record] = meter.getBatcher().checkPointSet();
       const ts = createTimeSeries(record, 'otel', new Date().toISOString());


### PR DESCRIPTION
`LabelSet` API is removed from `v0.6.1`. See: https://github.com/open-telemetry/opentelemetry-js/releases/tag/v0.6.0