### PR TITLE
fix: Cast integer label values to string

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -129,7 +129,7 @@ function transformMetric(
   const keys = metric.descriptor.labelKeys;
   for (let i = 0; i < keys.length; i++) {
     if (metric.labels[keys[i]] !== null) {
-      labels[keys[i]] = metric.labels[keys[i]].toString();
+      labels[keys[i]] = `${metric.labels[keys[i]]}`;
     }
   }
   labels[OPENTELEMETRY_TASK] = OPENTELEMETRY_TASK_VALUE_DEFAULT;

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -129,7 +129,7 @@ function transformMetric(
   const keys = metric.descriptor.labelKeys;
   for (let i = 0; i < keys.length; i++) {
     if (metric.labels[keys[i]] !== null) {
-      labels[keys[i]] = metric.labels[keys[i]];
+      labels[keys[i]] = metric.labels[keys[i]].toString();
     }
   }
   labels[OPENTELEMETRY_TASK] = OPENTELEMETRY_TASK_VALUE_DEFAULT;


### PR DESCRIPTION
## Summary

This PR is regarding Issue #77. 

Within transformMetric(...), I cast the variable to a string. This makes the behavior of the Google Cloud Monitoring exporter consistent with Prometheus. For example, a user can create `labels = {pid: process.pid};`, as they previously could with Prometheus' exporter.

## Test plan

All tests + linter pass. I also tested it on my local application, using both a string and an integer. 
![Screenshot 2020-05-27 at 5 49 35 PM](https://user-images.githubusercontent.com/3642085/83075820-7d60c100-a042-11ea-9e36-4ca28f335de9.png)
![Screenshot 2020-05-27 at 5 37 38 PM](https://user-images.githubusercontent.com/3642085/83075821-7d60c100-a042-11ea-8146-68998bdcdfdf.png)

I planned on including an additional unit test in the test file. However, I was unable to do so because the typescript mandates that the labels dictionary is {string : string}, and I cannot create a test case that is {string: number}