### PR TITLE
feat: Add resource within Google Cloud Monitoring Exporter

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/package.json
+++ b/packages/opentelemetry-cloud-monitoring-exporter/package.json
@@ -51,10 +51,10 @@
     "typescript": "3.9.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.7.0",
+    "@opentelemetry/api": "^0.8.3",
     "@opentelemetry/base": "^0.7.0",
-    "@opentelemetry/core": "^0.7.0",
-    "@opentelemetry/metrics": "^0.6.1",
+    "@opentelemetry/core": "^0.8.3",
+    "@opentelemetry/metrics": "^0.8.3",
     "google-auth-library": "^5.7.0",
     "googleapis": "^46.0.0"
   }

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
@@ -110,7 +110,7 @@ export class MetricExporter implements IMetricExporter {
           await createTimeSeries(
             metric,
             this._metricPrefix,
-            this._startTime, 
+            this._startTime,
             this._projectId
           )
         );

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
@@ -107,7 +107,7 @@ export class MetricExporter implements IMetricExporter {
       );
       if (isRegistered) {
         timeSeries.push(
-          createTimeSeries(metric, this._metricPrefix, this._startTime)
+          await createTimeSeries(metric, this._metricPrefix, this._startTime)
         );
       }
     }

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
@@ -107,7 +107,12 @@ export class MetricExporter implements IMetricExporter {
       );
       if (isRegistered) {
         timeSeries.push(
-          await createTimeSeries(metric, this._metricPrefix, this._startTime, this._projectId)
+          await createTimeSeries(
+            metric,
+            this._metricPrefix,
+            this._startTime, 
+            this._projectId
+          )
         );
       }
     }

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
@@ -107,7 +107,7 @@ export class MetricExporter implements IMetricExporter {
       );
       if (isRegistered) {
         timeSeries.push(
-          await createTimeSeries(
+          createTimeSeries(
             metric,
             this._metricPrefix,
             this._startTime,

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
@@ -107,7 +107,7 @@ export class MetricExporter implements IMetricExporter {
       );
       if (isRegistered) {
         timeSeries.push(
-          await createTimeSeries(metric, this._metricPrefix, this._startTime)
+          await createTimeSeries(metric, this._metricPrefix, this._startTime, this._projectId)
         );
       }
     }

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -250,7 +250,6 @@ function transformValue(
   } else if (valueType === OTValueType.DOUBLE) {
     return { doubleValue: value };
   }
-  // TODO: Add support for Distribution and Histogram
   throw Error(`unsupported value type: ${valueType}`);
 }
 

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -21,7 +21,11 @@ import {
   Point as OTPoint,
 } from '@opentelemetry/metrics';
 import { ValueType as OTValueType } from '@opentelemetry/api';
-import { Resource, CLOUD_RESOURCE, HOST_RESOURCE } from '@opentelemetry/resources';
+import {
+  Resource,
+  CLOUD_RESOURCE,
+  HOST_RESOURCE,
+} from '@opentelemetry/resources';
 import {
   MetricDescriptor,
   MetricKind,

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -123,21 +123,21 @@ export async function createTimeSeries(
 
 async function transformResource(
   projectId: string
-  ): Promise<{ type: string; labels: { [key: string]: string } }> {
+): Promise<{ type: string; labels: { [key: string]: string } }> {
   const resource: Resource = await detectResources();
-  const cloudProvider: string = `${resource.labels['cloud.provider']}`;
+  const cloudProvider = `${resource.labels['cloud.provider']}`;
   // These are the only supported resources
   if (cloudProvider === 'gcp') {
     return {
       type: 'gce_instance',
       labels: {
         instance_id: `${resource.labels['host.id']}`,
-        project_id: projectId, 
+        project_id: projectId,
         zone: `${resource.labels['cloud.zone']}`,
       },
     };
   } else if (cloudProvider === 'aws') {
-    return { 
+    return {
       type: 'aws_ec2_instance',
       labels: {
         instance_id: `${resource.labels['host.id']}`,

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -129,8 +129,8 @@ export function createTimeSeries(
 /**
  * Given a resource, return a MonitoredResource
  * If any field is missing, return the default resource
- * @param resource 
- * @param projectId 
+ * @param resource
+ * @param projectId
  */
 function transformResource(
   resource: Resource,
@@ -160,8 +160,8 @@ function transformResource(
 
 /**
  * Returns the type and mappings of a resource for a given cloud provider
- * The only currently supported cloud providers are GCP and AWS 
- * @param resource 
+ * The only currently supported cloud providers are GCP and AWS
+ * @param resource
  */
 function getTypeAndMappings(resource: Resource): MonitoredResource {
   const cloudProvider = `${resource.labels[CLOUD_RESOURCE.PROVIDER]}`;

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -17,6 +17,7 @@ import {
   MetricKind as OTMetricKind,
   MetricRecord,
   Distribution as OTDistribution,
+  Histogram as OTHistogram,
   Point as OTPoint,
 } from '@opentelemetry/metrics';
 import { ValueType as OTValueType } from '@opentelemetry/api';
@@ -167,14 +168,14 @@ function transformPoint(
 /** Transforms a OpenTelemetry Point's value to a StackDriver Point value. */
 function transformValue(
   valueType: OTValueType,
-  value: number | OTDistribution
+  value: number | OTDistribution | OTHistogram
 ) {
   if (valueType === OTValueType.INT) {
     return { int64Value: value as number };
   } else if (valueType === OTValueType.DOUBLE) {
     return { doubleValue: value as number };
   }
-  // TODO: Add support for Distribution
+  // TODO: Add support for Distribution and Histogram
   throw Error(`unsupported value type: ${valueType}`);
 }
 

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -33,6 +33,7 @@ import {
   ValueType,
   TimeSeries,
   Point,
+  MonitoredResource,
 } from './types';
 import * as path from 'path';
 import * as os from 'os';
@@ -131,7 +132,7 @@ export function createTimeSeries(
 function transformResource(
   resource: Resource,
   projectId: string
-): { type: string; labels: { [key: string]: string } } {
+): MonitoredResource {
   const templateResource = getTypeAndMappings(resource);
   const type = templateResource.type;
   const labels: { [key: string]: string } = { project_id: projectId };
@@ -155,9 +156,7 @@ function transformResource(
   return { type, labels };
 }
 
-function getTypeAndMappings(
-  resource: Resource
-): { type: string; labels: { [key: string]: string } } {
+function getTypeAndMappings(resource: Resource): MonitoredResource {
   const cloudProvider = `${resource.labels[CLOUD_RESOURCE.PROVIDER]}`;
   // These are the only supported resources
   if (cloudProvider === 'gcp') {

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -21,7 +21,7 @@ import {
   Point as OTPoint,
 } from '@opentelemetry/metrics';
 import { ValueType as OTValueType } from '@opentelemetry/api';
-import { Resource } from '@opentelemetry/resources';
+import { Resource, CLOUD_RESOURCE, HOST_RESOURCE } from '@opentelemetry/resources';
 import {
   MetricDescriptor,
   MetricKind,
@@ -35,6 +35,8 @@ import * as os from 'os';
 
 const OPENTELEMETRY_TASK = 'opentelemetry_task';
 const OPENTELEMETRY_TASK_DESCRIPTION = 'OpenTelemetry task identifier';
+const GCP_GCE_INSTANCE = 'gce_instance';
+const AWS_EC2_INSTANCE = 'aws_ec2_instance';
 export const OPENTELEMETRY_TASK_VALUE_DEFAULT = generateDefaultTaskValue();
 
 export function transformMetricDescriptor(
@@ -125,25 +127,25 @@ function transformResource(
   resource: Resource,
   projectId: string
 ): { type: string; labels: { [key: string]: string } } {
-  const cloudProvider = `${resource.labels['cloud.provider']}`;
+  const cloudProvider = `${resource.labels[CLOUD_RESOURCE.PROVIDER]}`;
   // These are the only supported resources
   if (cloudProvider === 'gcp') {
     return {
-      type: 'gce_instance',
+      type: GCP_GCE_INSTANCE,
       labels: {
-        instance_id: `${resource.labels['host.id']}`,
+        instance_id: `${resource.labels[HOST_RESOURCE.ID]}`,
         project_id: projectId,
-        zone: `${resource.labels['cloud.zone']}`,
+        zone: `${resource.labels[CLOUD_RESOURCE.ZONE]}`,
       },
     };
   } else if (cloudProvider === 'aws') {
     return {
-      type: 'aws_ec2_instance',
+      type: AWS_EC2_INSTANCE,
       labels: {
-        instance_id: `${resource.labels['host.id']}`,
+        instance_id: `${resource.labels[HOST_RESOURCE.ID]}`,
         project_id: projectId,
-        region: `${resource.labels['cloud.region']}`,
-        aws_account: `${resource.labels['cloud.account.id']}`,
+        region: `${resource.labels[CLOUD_RESOURCE.REGION]}`,
+        aws_account: `${resource.labels[CLOUD_RESOURCE.ACCOUNT_ID]}`,
       },
     };
   }

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -128,7 +128,6 @@ async function transformResource(projectId: string): Promise<{ type: string; lab
   for (var cloud_key in resource.labels) {
     resource_labels[cloud_key] = `${resource.labels[cloud_key]}`;
   }
-  console.log(resource_labels);
   // These are the only supported resources
   if (cloud_provider === 'gcp') {
     return { type: 'gce_instance', labels: { "instance_id": resource_labels['host.id'], "project_id": projectId, "zone": resource_labels['cloud.zone'] } };

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -21,7 +21,7 @@ import {
   Point as OTPoint,
 } from '@opentelemetry/metrics';
 import { ValueType as OTValueType } from '@opentelemetry/api';
-import { Resource, detectResources } from '@opentelemetry/resources';
+import { Resource } from '@opentelemetry/resources';
 import {
   MetricDescriptor,
   MetricKind,
@@ -104,15 +104,15 @@ function transformValueType(valueType: OTValueType): ValueType {
  * Converts metric's timeseries to a list of TimeSeries, so that metric can be
  * uploaded to StackDriver.
  */
-export async function createTimeSeries(
+export function createTimeSeries(
   metric: MetricRecord,
   metricPrefix: string,
   startTime: string,
   projectId: string
-): Promise<TimeSeries> {
+): TimeSeries {
   return {
     metric: transformMetric(metric, metricPrefix),
-    resource: await transformResource(projectId),
+    resource: transformResource(metric.resource, projectId),
     metricKind: transformMetricKind(metric.descriptor.metricKind),
     valueType: transformValueType(metric.descriptor.valueType),
     points: [
@@ -121,10 +121,10 @@ export async function createTimeSeries(
   };
 }
 
-async function transformResource(
+ function transformResource(
+  resource: Resource,
   projectId: string
-): Promise<{ type: string; labels: { [key: string]: string } }> {
-  const resource: Resource = await detectResources();
+): { type: string; labels: { [key: string]: string } } {
   const cloudProvider = `${resource.labels['cloud.provider']}`;
   // These are the only supported resources
   if (cloudProvider === 'gcp') {

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -121,7 +121,7 @@ export function createTimeSeries(
   };
 }
 
- function transformResource(
+function transformResource(
   resource: Resource,
   projectId: string
 ): { type: string; labels: { [key: string]: string } } {

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -108,7 +108,7 @@ export async function createTimeSeries(
   metric: MetricRecord,
   metricPrefix: string,
   startTime: string,
-  projectId: string,
+  projectId: string
 ): Promise<TimeSeries> {
   return {
     metric: transformMetric(metric, metricPrefix),
@@ -121,19 +121,31 @@ export async function createTimeSeries(
   };
 }
 
-async function transformResource(projectId: string): Promise<{ type: string; labels: { [key: string]: string } }> {
+async function transformResource(
+  projectId: string
+  ): Promise<{ type: string; labels: { [key: string]: string } }> {
   const resource: Resource = await detectResources();
-  const cloud_provider: String = `${resource.labels['cloud.provider']}`;
-  const resource_labels: { [key: string]: string } = {};
-  for (var cloud_key in resource.labels) {
-    resource_labels[cloud_key] = `${resource.labels[cloud_key]}`;
-  }
+  const cloudProvider: string = `${resource.labels['cloud.provider']}`;
   // These are the only supported resources
-  if (cloud_provider === 'gcp') {
-    return { type: 'gce_instance', labels: { "instance_id": resource_labels['host.id'], "project_id": projectId, "zone": resource_labels['cloud.zone'] } };
-  }
-  else if (cloud_provider === 'aws') {
-    return { type: 'aws_ec2_instance', labels: {"instance_id":resource_labels['host.id'],"project_id": projectId, "region": resource_labels['cloud.region'], "aws_account": resource_labels['cloud.account.id'], } };
+  if (cloudProvider === 'gcp') {
+    return {
+      type: 'gce_instance',
+      labels: {
+        instance_id: `${resource.labels['host.id']}`,
+        project_id: projectId, 
+        zone: `${resource.labels['cloud.zone']}`,
+      },
+    };
+  } else if (cloudProvider === 'aws') {
+    return { 
+      type: 'aws_ec2_instance',
+      labels: {
+        instance_id: `${resource.labels['host.id']}`,
+        project_id: projectId,
+        region: `${resource.labels['cloud.region']}`,
+        aws_account: `${resource.labels['cloud.account.id']}`,
+      },
+    };
   }
   return { type: 'global', labels: {} };
 }

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
@@ -148,7 +148,7 @@ describe('MetricExporter', () => {
 
     it('should export metrics', async () => {
       const meter = new MeterProvider().getMeter('test-meter');
-      const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };
+      const labels: Labels = { ['keya']: 'value1', ['keyb']: 'value2' };
       const counter = meter.createCounter('name');
       counter.add(10, labels);
       meter.collect();
@@ -170,7 +170,7 @@ describe('MetricExporter', () => {
 
     it('should return retryable if there is an error sending TimeSeries', async () => {
       const meter = new MeterProvider().getMeter('test-meter');
-      const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };
+      const labels: Labels = { ['keya']: 'value1', ['keyb']: 'value2' };
       const counter = meter.createCounter('name');
       counter.add(10, labels);
       meter.collect();
@@ -193,7 +193,7 @@ describe('MetricExporter', () => {
     it('should enforce batch size limit on metrics', async () => {
       const meter = new MeterProvider().getMeter('test-meter');
 
-      const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };
+      const labels: Labels = { ['keya']: 'value1', ['keyb']: 'value2' };
       let nMetrics = 401;
       while (nMetrics > 0) {
         nMetrics -= 1;

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -90,6 +90,10 @@ describe('transform', () => {
         TEST_ONLY.transformValueType(OTValueType.DOUBLE),
         ValueType.DOUBLE
       );
+      assert.strictEqual(
+        TEST_ONLY.transformValueType(2),
+        ValueType.VALUE_TYPE_UNSPECIFIED
+      );
     });
 
     it('should return a Google Cloud Monitoring DisplayName', () => {

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -235,7 +235,7 @@ describe('transform', () => {
       const meter = new MeterProvider({
         resource: new Resource(mockGCResource),
       }).getMeter('test-meter');
-      const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };
+      const labels: Labels = { ['keya']: 'value1', ['keyb']: 'value2' };
       const counter = meter.createCounter(METRIC_NAME, {
         description: METRIC_DESCRIPTION,
       });
@@ -260,7 +260,7 @@ describe('transform', () => {
       const meter = new MeterProvider({
         resource: new Resource(incompleteResource),
       }).getMeter('test-meter');
-      const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };
+      const labels: Labels = { ['keya']: 'value1', ['keyb']: 'value2' };
       const counter = meter.createCounter(METRIC_NAME, {
         description: METRIC_DESCRIPTION,
       });

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -149,29 +149,29 @@ describe('transform', () => {
       'cloud.provider': 'aws',
       'host.id': 'host_id',
       'cloud.region': 'my-region',
-      'cloud.account.id': '12345'
+      'cloud.account.id': '12345',
     };
-    const mockedAwsConvertedResource = {
-      type: "aws_ec2_instance",
+    const mockedAwsMonitoredResource = {
+      type: 'aws_ec2_instance',
       labels: {
         instance_id: 'host_id',
-        project_id: 'project_id', 
+        project_id: 'project_id',
         region: 'my-region',
-        aws_account: '12345'
-      }
+        aws_account: '12345',
+      },
     };
     const mockedGCResource = {
       'cloud.provider': 'gcp',
       'host.id': 'host_id',
       'cloud.zone': 'my-zone',
     };
-    const mockedGCConvertedResource = {
+    const mockedGCMonitoredResource = {
       type: 'gce_instance',
       labels: {
         instance_id: 'host_id',
         project_id: 'project_id',
         zone: 'my-zone',
-      }
+      },
     };
 
     it('should return a Google Cloud Monitoring Metric with a default resource', () => {
@@ -204,7 +204,9 @@ describe('transform', () => {
       assert.deepStrictEqual(ts.points[0].value, { doubleValue: 10 });
     });
     it('should detect an AWS instance', () => {
-      const meter = new MeterProvider({resource: new Resource(mockedAwsResource)}).getMeter('test-meter');
+      const meter = new MeterProvider({
+        resource: new Resource(mockedAwsResource),
+      }).getMeter('test-meter');
       const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };
       const counter = meter.createCounter(METRIC_NAME, {
         description: METRIC_DESCRIPTION,
@@ -219,10 +221,12 @@ describe('transform', () => {
         new Date().toISOString(),
         'project_id'
       );
-      assert.deepStrictEqual(ts.resource, mockedAwsConvertedResource);
+      assert.deepStrictEqual(ts.resource, mockedAwsMonitoredResource);
     });
     it('should detect a Google Cloud VM instance', () => {
-      const meter = new MeterProvider({resource: new Resource(mockedGCResource)}).getMeter('test-meter');
+      const meter = new MeterProvider(
+        {resource: new Resource(mockedGCResource),
+      }).getMeter('test-meter');
       const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };
       const counter = meter.createCounter(METRIC_NAME, {
         description: METRIC_DESCRIPTION,
@@ -237,7 +241,7 @@ describe('transform', () => {
         new Date().toISOString(),
         'project_id'
       );
-      assert.deepStrictEqual(ts.resource, mockedGCConvertedResource);
+      assert.deepStrictEqual(ts.resource, mockedGCMonitoredResource);
     });
   });
 });

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -274,124 +274,129 @@ describe('transform', () => {
         type: 'global',
       });
 
-    it('should return a Google Cloud Monitoring Metric for an observer', () => {
-      const meter = new MeterProvider().getMeter('test-meter');
-      const labels: Labels = { keyb: 'value2', keya: 'value1' };
-      const observer = meter.createObserver(METRIC_NAME, {
-        description: METRIC_DESCRIPTION,
-        valueType: OTValueType.INT,
+      it('should return a Google Cloud Monitoring Metric for an observer', () => {
+        const meter = new MeterProvider().getMeter('test-meter');
+        const labels: Labels = { keyb: 'value2', keya: 'value1' };
+        const observer = meter.createObserver(METRIC_NAME, {
+          description: METRIC_DESCRIPTION,
+          valueType: OTValueType.INT,
+        });
+        const int64Value = 0;
+        observer.setCallback(result => {
+          result.observe(() => int64Value, labels);
+        });
+        meter.collect();
+        const [record] = meter.getBatcher().checkPointSet();
+        const ts = createTimeSeries(
+          record,
+          'otel',
+          new Date().toISOString(),
+          'project_id'
+        );
+        assert(!ts.points[0].interval.startTime);
+        assert(ts.points[0].interval.endTime);
+        assert.strictEqual(ts.metric.type, `otel/${METRIC_NAME}`);
+        assert.strictEqual(ts.metric.labels['keya'], 'value1');
+        assert.strictEqual(ts.metric.labels['keyb'], 'value2');
+        assert.strictEqual(
+          ts.metric.labels[TEST_ONLY.OPENTELEMETRY_TASK],
+          OPENTELEMETRY_TASK_VALUE_DEFAULT
+        );
+        assert.deepStrictEqual(ts.resource, {
+          labels: {},
+          type: 'global',
+        });
+        assert.strictEqual(ts.metricKind, MetricKind.GAUGE);
+        assert.strictEqual(ts.valueType, ValueType.INT64);
+        assert.strictEqual(ts.points.length, 1);
+        assert.deepStrictEqual(ts.points[0].value, { int64Value });
       });
-      const int64Value = 0;
-      observer.setCallback(result => {
-        result.observe(() => int64Value, labels);
-      });
-      meter.collect();
-      const [record] = meter.getBatcher().checkPointSet();
-      const ts = createTimeSeries(record, 'otel', new Date().toISOString(), 'project_id');
-      assert(!ts.points[0].interval.startTime);
-      assert(ts.points[0].interval.endTime);
-      assert.strictEqual(ts.metric.type, `otel/${METRIC_NAME}`);
-      assert.strictEqual(ts.metric.labels['keya'], 'value1');
-      assert.strictEqual(ts.metric.labels['keyb'], 'value2');
-      assert.strictEqual(
-        ts.metric.labels[TEST_ONLY.OPENTELEMETRY_TASK],
-        OPENTELEMETRY_TASK_VALUE_DEFAULT
-      );
-      assert.deepStrictEqual(ts.resource, {
-        labels: {},
-        type: 'global',
-      });
-      assert.strictEqual(ts.metricKind, MetricKind.GAUGE);
-      assert.strictEqual(ts.valueType, ValueType.INT64);
-      assert.strictEqual(ts.points.length, 1);
-      assert.deepStrictEqual(ts.points[0].value, { int64Value });
-    });
 
-    it('should return a point', () => {
-      const metricDescriptor: OTMetricDescriptor = {
-        name: METRIC_NAME,
-        description: METRIC_DESCRIPTION,
-        unit: DEFAULT_UNIT,
-        metricKind: OTMetricKind.OBSERVER,
-        valueType: OTValueType.INT,
-      };
-      const point: OTPoint = {
-        value: 50,
-        timestamp: process.hrtime(),
-      };
+      it('should return a point', () => {
+        const metricDescriptor: OTMetricDescriptor = {
+          name: METRIC_NAME,
+          description: METRIC_DESCRIPTION,
+          unit: DEFAULT_UNIT,
+          metricKind: OTMetricKind.OBSERVER,
+          valueType: OTValueType.INT,
+        };
+        const point: OTPoint = {
+          value: 50,
+          timestamp: process.hrtime(),
+        };
 
-      const result = TEST_ONLY.transformPoint(
-        point,
-        metricDescriptor,
-        new Date().toISOString()
-      );
-
-      assert.deepStrictEqual(result.value, { int64Value: 50 });
-      assert(result.interval.endTime);
-      assert(!result.interval.startTime);
-    });
-
-    it('should throw an error when given a distribution value', () => {
-      const metricDescriptor: OTMetricDescriptor = {
-        name: METRIC_NAME,
-        description: METRIC_DESCRIPTION,
-        unit: DEFAULT_UNIT,
-        metricKind: OTMetricKind.COUNTER,
-        valueType: OTValueType.DOUBLE,
-      };
-      const point: OTPoint = {
-        value: {
-          min: 20.0,
-          max: 75.4,
-          count: 22,
-          sum: 150,
-        },
-        timestamp: process.hrtime(),
-      };
-
-      try {
-        TEST_ONLY.transformPoint(
+        const result = TEST_ONLY.transformPoint(
           point,
           metricDescriptor,
           new Date().toISOString()
         );
-        assert.fail('should have thrown an error');
-      } catch (err) {
-        assert(err.message.toLowerCase().includes('distributions'));
-      }
-    });
 
-    it('should thrown an error when given a histrogram value', () => {
-      const metricDescriptor: OTMetricDescriptor = {
-        name: METRIC_NAME,
-        description: METRIC_DESCRIPTION,
-        unit: DEFAULT_UNIT,
-        metricKind: OTMetricKind.COUNTER,
-        valueType: OTValueType.DOUBLE,
-      };
-      const point: OTPoint = {
-        value: {
-          buckets: {
-            boundaries: [10, 30],
-            counts: [1, 2],
+        assert.deepStrictEqual(result.value, { int64Value: 50 });
+        assert(result.interval.endTime);
+        assert(!result.interval.startTime);
+      });
+
+      it('should throw an error when given a distribution value', () => {
+        const metricDescriptor: OTMetricDescriptor = {
+          name: METRIC_NAME,
+          description: METRIC_DESCRIPTION,
+          unit: DEFAULT_UNIT,
+          metricKind: OTMetricKind.COUNTER,
+          valueType: OTValueType.DOUBLE,
+        };
+        const point: OTPoint = {
+          value: {
+            min: 20.0,
+            max: 75.4,
+            count: 22,
+            sum: 150,
           },
-          sum: 70,
-          count: 3,
-        },
-        timestamp: process.hrtime(),
-      };
+          timestamp: process.hrtime(),
+        };
 
-      try {
-        TEST_ONLY.transformPoint(
-          point,
-          metricDescriptor,
-          new Date().toISOString()
-        );
-        assert.fail('should have thrown an error');
-      } catch (err) {
-        assert(err.message.toLowerCase().includes('histograms'));
-      }
+        try {
+          TEST_ONLY.transformPoint(
+            point,
+            metricDescriptor,
+            new Date().toISOString()
+          );
+          assert.fail('should have thrown an error');
+        } catch (err) {
+          assert(err.message.toLowerCase().includes('distributions'));
+        }
+      });
+
+      it('should thrown an error when given a histrogram value', () => {
+        const metricDescriptor: OTMetricDescriptor = {
+          name: METRIC_NAME,
+          description: METRIC_DESCRIPTION,
+          unit: DEFAULT_UNIT,
+          metricKind: OTMetricKind.COUNTER,
+          valueType: OTValueType.DOUBLE,
+        };
+        const point: OTPoint = {
+          value: {
+            buckets: {
+              boundaries: [10, 30],
+              counts: [1, 2],
+            },
+            sum: 70,
+            count: 3,
+          },
+          timestamp: process.hrtime(),
+        };
+
+        try {
+          TEST_ONLY.transformPoint(
+            point,
+            metricDescriptor,
+            new Date().toISOString()
+          );
+          assert.fail('should have thrown an error');
+        } catch (err) {
+          assert(err.message.toLowerCase().includes('histograms'));
+        }
+      });
     });
-  });
   });
 });

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -159,10 +159,10 @@ describe('transform', () => {
       assert.strictEqual(ts.metric.type, 'otel/metric-name');
       assert.strictEqual(ts.metric.labels['keya'], 'value1');
       assert.strictEqual(ts.metric.labels['keyb'], 'value2');
-      assert.deepStrictEqual(ts.resource, {
+      /*assert.deepStrictEqual(ts.resource, {
         labels: {},
         type: 'global',
-      });
+      });*/
       assert.strictEqual(ts.metricKind, MetricKind.CUMULATIVE);
       assert.strictEqual(ts.valueType, ValueType.DOUBLE);
       assert.strictEqual(ts.points.length, 1);

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -145,13 +145,13 @@ describe('transform', () => {
   });
 
   describe('TimeSeries', () => {
-    const mockedAwsResource = {
+    const mockAwsResource = {
       'cloud.provider': 'aws',
       'host.id': 'host_id',
       'cloud.region': 'my-region',
       'cloud.account.id': '12345',
     };
-    const mockedAwsMonitoredResource = {
+    const mockAwsMonitoredResource = {
       type: 'aws_ec2_instance',
       labels: {
         instance_id: 'host_id',
@@ -160,12 +160,12 @@ describe('transform', () => {
         aws_account: '12345',
       },
     };
-    const mockedGCResource = {
+    const mockGCResource = {
       'cloud.provider': 'gcp',
       'host.id': 'host_id',
       'cloud.zone': 'my-zone',
     };
-    const mockedGCMonitoredResource = {
+    const mockGCMonitoredResource = {
       type: 'gce_instance',
       labels: {
         instance_id: 'host_id',
@@ -205,7 +205,7 @@ describe('transform', () => {
     });
     it('should detect an AWS instance', () => {
       const meter = new MeterProvider({
-        resource: new Resource(mockedAwsResource),
+        resource: new Resource(mockAwsResource),
       }).getMeter('test-meter');
       const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };
       const counter = meter.createCounter(METRIC_NAME, {
@@ -221,11 +221,11 @@ describe('transform', () => {
         new Date().toISOString(),
         'project_id'
       );
-      assert.deepStrictEqual(ts.resource, mockedAwsMonitoredResource);
+      assert.deepStrictEqual(ts.resource, mockAwsMonitoredResource);
     });
     it('should detect a Google Cloud VM instance', () => {
       const meter = new MeterProvider({
-        resource: new Resource(mockedGCResource),
+        resource: new Resource(mockGCResource),
       }).getMeter('test-meter');
       const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };
       const counter = meter.createCounter(METRIC_NAME, {
@@ -241,7 +241,7 @@ describe('transform', () => {
         new Date().toISOString(),
         'project_id'
       );
-      assert.deepStrictEqual(ts.resource, mockedGCMonitoredResource);
+      assert.deepStrictEqual(ts.resource, mockGCMonitoredResource);
     });
 
     it('should return global for an incomplete resource', () => {

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -143,8 +143,8 @@ describe('transform', () => {
     });
   });
 
-  describe('TimeSeries', () => {
-    it('should return a Google Cloud Monitoring Metric', () => {
+  describe('TimeSeries', async () => {
+    it('should return a Google Cloud Monitoring Metric', async () => {
       const meter = new MeterProvider().getMeter('test-meter');
       const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };
 
@@ -155,7 +155,7 @@ describe('transform', () => {
       counter.bind(labels).add(10);
       meter.collect();
       const [record] = meter.getBatcher().checkPointSet();
-      const ts = createTimeSeries(record, 'otel', new Date().toISOString());
+      const ts = await createTimeSeries(record, 'otel', new Date().toISOString());
       assert.strictEqual(ts.metric.type, 'otel/metric-name');
       assert.strictEqual(ts.metric.labels['keya'], 'value1');
       assert.strictEqual(ts.metric.labels['keyb'], 'value2');

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -224,8 +224,8 @@ describe('transform', () => {
       assert.deepStrictEqual(ts.resource, mockedAwsMonitoredResource);
     });
     it('should detect a Google Cloud VM instance', () => {
-      const meter = new MeterProvider(
-        {resource: new Resource(mockedGCResource),
+      const meter = new MeterProvider({
+        resource: new Resource(mockedGCResource),
       }).getMeter('test-meter');
       const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };
       const counter = meter.createCounter(METRIC_NAME, {

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -176,7 +176,7 @@ describe('transform', () => {
 
     it('should return a Google Cloud Monitoring Metric with a default resource', () => {
       const meter = new MeterProvider().getMeter('test-meter');
-      const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };
+      const labels: Labels = { ['keya']: 'value1', ['keyb']: 'value2' };
 
       const counter = meter.createCounter(METRIC_NAME, {
         description: METRIC_DESCRIPTION,
@@ -207,7 +207,7 @@ describe('transform', () => {
       const meter = new MeterProvider({
         resource: new Resource(mockAwsResource),
       }).getMeter('test-meter');
-      const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };
+      const labels: Labels = { ['keya']: 'value1', ['keyb']: 'value2' };
       const counter = meter.createCounter(METRIC_NAME, {
         description: METRIC_DESCRIPTION,
         labelKeys: ['keya', 'keyb'],

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -155,7 +155,12 @@ describe('transform', () => {
       counter.bind(labels).add(10);
       meter.collect();
       const [record] = meter.getBatcher().checkPointSet();
-      const ts = await createTimeSeries(record, 'otel', new Date().toISOString(),'project_id');
+      const ts = await createTimeSeries(
+        record,
+        'otel',
+        new Date().toISOString(),
+        'project_id'
+      );
       assert.strictEqual(ts.metric.type, 'otel/metric-name');
       assert.strictEqual(ts.metric.labels['keya'], 'value1');
       assert.strictEqual(ts.metric.labels['keyb'], 'value2');

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -155,7 +155,7 @@ describe('transform', () => {
       counter.bind(labels).add(10);
       meter.collect();
       const [record] = meter.getBatcher().checkPointSet();
-      const ts = await createTimeSeries(record, 'otel', new Date().toISOString());
+      const ts = await createTimeSeries(record, 'otel', new Date().toISOString(),'project_id');
       assert.strictEqual(ts.metric.type, 'otel/metric-name');
       assert.strictEqual(ts.metric.labels['keya'], 'value1');
       assert.strictEqual(ts.metric.labels['keyb'], 'value2');


### PR DESCRIPTION
# Summary
This PR is regarding Issue #79. 

Within createTimeSeries(...), I call detectResources, within @OpenTelemetry/resources. This determines whether it's an AWS EC2 Instance, a Google Cloud VM Instance, or another resource type. I convert it to a format which Stackdriver can accept.

I looked at the OpenCensus StackDriver exporter to determine the correct resource labels: https://github.com/census-instrumentation/opencensus-node/blob/master/packages/opencensus-exporter-stackdriver/src/common-utils.ts

I also updated the versions of the dependencies to allow for resource checking. This required a minor change (altering the type of one parameter). 

# Test Plan

I tested it locally on my Google Cloud VM Instance, and it successfully displayed metrics under the resource type "GCE VM Instance". 
![Screenshot 2020-06-03 at 3 40 31 PM](https://user-images.githubusercontent.com/3642085/83681556-97ede980-a5b0-11ea-8222-7a327365f956.png)

## Problem setting up testing
Within transform.tests, I planned on mocking the environment to mimic AWS, GCP, and other. I planned on using Sinon to mock detectResources(...), but I couldn't because it's a standalone function. I had to also disable the resource check in the test. 

Do you have any suggestions for setting up testing for this code change?