### PR TITLE
fix: Stackdriver batch limit for TimeSeries

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
@@ -25,6 +25,11 @@ import { GoogleAuth, JWT } from 'google-auth-library';
 import { google } from 'googleapis';
 import { transformMetricDescriptor, createTimeSeries } from './transform';
 import { TimeSeries } from './types';
+import { partitionList } from './utils';
+
+// Stackdriver Monitoring v3 only accepts up to 200 TimeSeries per
+// CreateTimeSeries call.
+const MAX_BATCH_EXPORT_SIZE = 200;
 
 const OT_USER_AGENT = {
   product: 'opentelemetry-js',
@@ -111,7 +116,13 @@ export class MetricExporter implements IMetricExporter {
         );
       }
     }
-    this._sendTimeSeries(timeSeries);
+
+    for (const batchedTimeSeries of partitionList(
+      timeSeries,
+      MAX_BATCH_EXPORT_SIZE
+    )) {
+      await this._sendTimeSeries(batchedTimeSeries);
+    }
     cb(ExportResult.SUCCESS);
   }
 

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -99,7 +99,7 @@ function transformValueType(valueType: OTValueType): ValueType {
 }
 
 /**
- * Converts metric's timeseries to a list of TimeSeries, so that metric can be
+ * Converts metric's timeseries to a TimeSeries, so that metric can be
  * uploaded to StackDriver.
  */
 export function createTimeSeries(

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/utils.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/utils.ts
@@ -1,0 +1,26 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  TimeSeries,
+} from './types';
+
+/** Returns an array with arrays of the given size. */
+export function partitionList(list: TimeSeries[], chunkSize: number) {
+  const results = [];
+  while (list.length) {
+    results.push(list.splice(0, chunkSize));
+  }
+  return results;
+}

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/utils.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/utils.ts
@@ -14,7 +14,7 @@
 
 import { TimeSeries } from './types';
 
-/** Returns an array with arrays of the given size. */
+/** Returns the minimum number of arrays of max size chunkSize, partitioned from the given array. */
 export function partitionList(list: TimeSeries[], chunkSize: number) {
   const listCopy = [...list];
   const results = [];

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/utils.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/utils.ts
@@ -16,9 +16,10 @@ import { TimeSeries } from './types';
 
 /** Returns an array with arrays of the given size. */
 export function partitionList(list: TimeSeries[], chunkSize: number) {
+  const listCopy = [...list];
   const results = [];
-  while (list.length) {
-    results.push(list.splice(0, chunkSize));
+  while (listCopy.length) {
+    results.push(listCopy.splice(0, chunkSize));
   }
   return results;
 }

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/utils.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/utils.ts
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  TimeSeries,
-} from './types';
+import { TimeSeries } from './types';
 
 /** Returns an array with arrays of the given size. */
 export function partitionList(list: TimeSeries[], chunkSize: number) {

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
@@ -77,7 +77,7 @@ describe('MetricExporter', () => {
           callback: (err: Error | null) => void
         ): any => {
           callback(null);
-        } 
+        }
       );
 
       sinon.replace(
@@ -163,7 +163,7 @@ describe('MetricExporter', () => {
 
       assert.equal(metricDescriptors.callCount, 1);
       assert.equal(timeSeries.callCount, 1);
-      
+
       assert.deepStrictEqual(result, ExportResult.SUCCESS);
     });
 

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
@@ -71,9 +71,13 @@ describe('MetricExporter', () => {
 
       metricDescriptors = sinon.spy(
         /* tslint:disable no-any */
-        (request: any, params: any, callback: (err: Error | null) => void): any => {
+        (
+          request: any,
+          params: any,
+          callback: (err: Error | null) => void
+        ): any => {
           callback(null);
-        }
+        } 
       );
 
       sinon.replace(
@@ -85,7 +89,11 @@ describe('MetricExporter', () => {
 
       timeSeries = sinon.spy(
         /* tslint:disable no-any */
-        (request: any, params: any, callback: (err: Error | null) => void): any => {
+        (
+          request: any,
+          params: any,
+          callback: (err: Error | null) => void
+        ): any => {
           callback(null);
         }
       );
@@ -153,20 +161,19 @@ describe('MetricExporter', () => {
         'custom.googleapis.com/opentelemetry/name'
       );
 
-      assert.equal(metricDescriptors.callCount, 1)
-      assert.equal(timeSeries.callCount, 1)
+      assert.equal(metricDescriptors.callCount, 1);
+      assert.equal(timeSeries.callCount, 1);
       
       assert.deepStrictEqual(result, ExportResult.SUCCESS);
     });
 
     it('should enforce batch size limit on metrics', async () => {
-
       const meter = new MeterProvider().getMeter('test-meter');
 
       const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };
-      let nMetrics = 401
+      let nMetrics = 401;
       while (nMetrics > 0) {
-        nMetrics -= 1
+        nMetrics -= 1;
         const counter = meter.createCounter(`name${nMetrics.toString()}`, {
           labelKeys: ['keya', 'keyb'],
         });
@@ -194,8 +201,8 @@ describe('MetricExporter', () => {
         'custom.googleapis.com/opentelemetry/name0'
       );
 
-      assert.equal(metricDescriptors.callCount, 401)
-      assert.equal(timeSeries.callCount, 3)
+      assert.equal(metricDescriptors.callCount, 401);
+      assert.equal(timeSeries.callCount, 3);
 
       assert.deepStrictEqual(result, ExportResult.SUCCESS);
     });

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
@@ -153,6 +153,9 @@ describe('MetricExporter', () => {
         'custom.googleapis.com/opentelemetry/name'
       );
 
+      assert.equal(metricDescriptors.callCount, 1)
+      assert.equal(timeSeries.callCount, 1)
+      
       assert.deepStrictEqual(result, ExportResult.SUCCESS);
     });
 


### PR DESCRIPTION
**Description:**
* Adds a batch limit of 200 to TimeSeries sent due to limit in Stackdriver backend.

**Smaller changes:**
* Adds helper function for partitioning batches
* Fixes misleading comment in `transform.ts`
* Fixes parameter mismatch error being throw by `metricDescriptors` spy

**Previous implementation in OpenCensus:**
https://github.com/census-instrumentation/opencensus-node/pull/644

Fixes #87