### PR TITLE
feat: use gRPC to write spans to cloud trace

### DIFF
--- a/packages/opentelemetry-cloud-trace-exporter/package-lock.json
+++ b/packages/opentelemetry-cloud-trace-exporter/package-lock.json
@@ -282,6 +282,15 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@grpc/proto-loader": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.5.tgz",
+      "integrity": "sha512-WwN9jVNdHRQoOBo9FDH7qU+mgfjPc8GygPYms3M+y3fbQLfnCe/Kv/E01t7JRgnrsOHH8euvSbed3mIalXhwqQ==",
+      "requires": {
+        "lodash.camelcase": "^4.3.0",
+        "protobufjs": "^6.8.6"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -376,6 +385,60 @@
         "@opentelemetry/resources": "^0.7.0"
       }
     },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -442,6 +505,15 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@types/bytebuffer": {
+      "version": "5.0.41",
+      "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.41.tgz",
+      "integrity": "sha512-Mdrv4YcaHvpkx25ksqqFaezktx3yZRcd51GZY0rY/9avyaqZdiT/GiWRhfrJhMpgzXqTOSHgGvsumGxJFNiZZA==",
+      "requires": {
+        "@types/long": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -467,6 +539,11 @@
       "dev": true,
       "optional": true
     },
+    "@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+    },
     "@types/minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
@@ -482,8 +559,7 @@
     "@types/node": {
       "version": "12.12.51",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.51.tgz",
-      "integrity": "sha512-6ILqt8iNThALrxDv2Q4LyYFQxULQz96HKNIFd4s9QRQaiHINYeUpLqeU/2IU7YMtvipG1fQVAy//vY8/fX1Y9w==",
-      "dev": true
+      "integrity": "sha512-6ILqt8iNThALrxDv2Q4LyYFQxULQz96HKNIFd4s9QRQaiHINYeUpLqeU/2IU7YMtvipG1fQVAy//vY8/fX1Y9w=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -564,6 +640,11 @@
           "dev": true
         }
       }
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "abort-controller": {
       "version": "3.0.0",
@@ -707,11 +788,25 @@
         "default-require-extensions": "^3.0.0"
       }
     },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
     },
     "argparse": {
       "version": "1.0.10",
@@ -733,6 +828,15 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
     },
+    "ascli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
+      "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
+      "requires": {
+        "colour": "~0.7.1",
+        "optjs": "~3.2.2"
+      }
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -742,8 +846,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
       "version": "1.3.1",
@@ -799,7 +902,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -830,6 +932,21 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
+    },
+    "bytebuffer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+      "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
+      "requires": {
+        "long": "~3"
+      },
+      "dependencies": {
+        "long": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+          "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+        }
+      }
     },
     "cacheable-request": {
       "version": "6.1.0",
@@ -929,6 +1046,11 @@
         "readdirp": "~3.2.0"
       }
     },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -1007,6 +1129,11 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
     "codecov": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.7.2.tgz",
@@ -1035,6 +1162,11 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "colour": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
+      "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1044,8 +1176,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "configstore": {
       "version": "5.0.1",
@@ -1060,6 +1191,11 @@
         "write-file-atomic": "^3.0.0",
         "xdg-basedir": "^4.0.0"
       }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -1077,6 +1213,11 @@
           "dev": true
         }
       }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -1116,8 +1257,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decamelize-keys": {
       "version": "1.1.0",
@@ -1149,8 +1289,7 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1181,6 +1320,16 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "diff": {
       "version": "3.5.0",
@@ -1800,11 +1949,18 @@
       "integrity": "sha512-Xu2Qh8yqYuDhQGOhD5iJGninErSfI9A3FrriD3tjUgV5VbJFeH8vfgZ9HnC6jWN80QDVNQK5vmxRAmEAp7Mevw==",
       "dev": true
     },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "requires": {
+        "minipass": "^2.6.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.1.3",
@@ -1824,6 +1980,54 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
     },
     "gaxios": {
       "version": "2.3.4",
@@ -1874,7 +2078,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1946,26 +2149,13 @@
         "node-forge": "^0.9.0"
       }
     },
-    "googleapis": {
-      "version": "46.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-46.0.0.tgz",
-      "integrity": "sha512-MOA6Qpu0jQfdnWZEyoAfW6duhWZxZxgrIzOtxNmsSj0WgLfot2s0vcAAq7MtCo1OX+/SduCsdJjCzq2tmhuxFw==",
+    "google-proto-files": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/google-proto-files/-/google-proto-files-2.2.0.tgz",
+      "integrity": "sha512-sSzjssqNqLRl3+vF+IdXGcYsOjZAf1veOEQFc5f3cR8WReoNsdg3laxu9sq7vgQ/OL/sjCp7I+917e79iJNcIQ==",
       "requires": {
-        "google-auth-library": "^5.6.1",
-        "googleapis-common": "^3.2.0"
-      }
-    },
-    "googleapis-common": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-3.2.2.tgz",
-      "integrity": "sha512-sTEXlauVce4eMX0S6hVoiWgxVzQZ7dc16KcGF7eh+A+uIyDgXqnuwOMZw+svX4gOJv6w4ACecm23Qh9UDaldsw==",
-      "requires": {
-        "extend": "^3.0.2",
-        "gaxios": "^2.0.1",
-        "google-auth-library": "^5.6.1",
-        "qs": "^6.7.0",
-        "url-template": "^2.0.8",
-        "uuid": "^7.0.0"
+        "protobufjs": "^6.8.0",
+        "walkdir": "^0.4.0"
       }
     },
     "got": {
@@ -2009,6 +2199,106 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
+    },
+    "grpc": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.3.tgz",
+      "integrity": "sha512-EDemzuZTfhM0hgrXqC4PtR76O3t+hTIYJYR5vgiW0yt2WJqo4mhxUqZUirzUQz34Psz7dbLp38C6Cl7Ij2vXRQ==",
+      "requires": {
+        "@types/bytebuffer": "^5.0.40",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.clone": "^4.5.0",
+        "nan": "^2.13.2",
+        "node-pre-gyp": "^0.15.0",
+        "protobufjs": "^5.0.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "protobufjs": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
+          "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+          "requires": {
+            "ascli": "~1",
+            "bytebuffer": "~5",
+            "glob": "^7.0.5",
+            "yargs": "^3.10.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "requires": {
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
+          }
+        }
+      }
     },
     "gtoken": {
       "version": "4.1.4",
@@ -2070,6 +2360,11 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-yarn": {
       "version": "2.1.0",
@@ -2141,7 +2436,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -2156,7 +2450,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
       "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
-      "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
       }
@@ -2193,7 +2486,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2202,14 +2494,12 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "7.3.3",
@@ -2242,6 +2532,11 @@
           }
         }
       }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -2656,6 +2951,14 @@
         "package-json": "^6.3.0"
       }
     },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -2686,6 +2989,16 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -2759,6 +3072,11 @@
           }
         }
       }
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -2865,7 +3183,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -2873,8 +3190,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -2895,11 +3211,27 @@
         }
       }
     },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "requires": {
+        "minipass": "^2.9.0"
+      }
+    },
     "mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -3049,6 +3381,11 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3060,6 +3397,26 @@
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "dev": true
+    },
+    "needle": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.0.tgz",
+      "integrity": "sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==",
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "nice-try": {
       "version": "1.0.5",
@@ -3120,6 +3477,38 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
       "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
     },
+    "node-pre-gyp": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz",
+      "integrity": "sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==",
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.3",
+        "needle": "^2.5.0",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4.4.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "node-preload": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
@@ -3127,6 +3516,15 @@
       "dev": true,
       "requires": {
         "process-on-spawn": "^1.0.0"
+      }
+    },
+    "nopt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+      "requires": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
       }
     },
     "normalize-package-data": {
@@ -3161,6 +3559,29 @@
       "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
       "dev": true
     },
+    "npm-bundled": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+    },
+    "npm-packlist": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
     "npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -3177,6 +3598,22 @@
           "dev": true
         }
       }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nyc": {
       "version": "15.1.0",
@@ -3271,6 +3708,11 @@
         }
       }
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
@@ -3309,7 +3751,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -3337,11 +3778,37 @@
         "word-wrap": "~1.2.3"
       }
     },
+    "optjs": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
+      "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "requires": {
+        "lcid": "^1.0.0"
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
     },
     "p-cancelable": {
       "version": "1.1.0",
@@ -3444,8 +3911,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",
@@ -3510,6 +3976,11 @@
         "fast-diff": "^1.1.2"
       }
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "process-on-spawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -3530,6 +4001,33 @@
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
+    },
+    "protobufjs": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.1.tgz",
+      "integrity": "sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": "^13.7.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.15",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
+          "integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw=="
+        }
+      }
     },
     "pump": {
       "version": "3.0.0",
@@ -3556,11 +4054,6 @@
         "escape-goat": "^2.0.0"
       }
     },
-    "qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
-    },
     "quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -3571,7 +4064,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -3582,8 +4074,7 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         }
       }
     },
@@ -3616,6 +4107,32 @@
         "find-up": "^4.1.0",
         "read-pkg": "^5.2.0",
         "type-fest": "^0.8.1"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "readdirp": {
@@ -3748,8 +4265,12 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
       "version": "7.3.2",
@@ -3776,8 +4297,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -3797,8 +4317,7 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "sinon": {
       "version": "9.0.2",
@@ -4004,6 +4523,21 @@
         "es-abstract": "^1.17.5"
       }
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -4098,6 +4632,20 @@
             "strip-ansi": "^5.1.0"
           }
         }
+      }
+    },
+    "tar": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.8.6",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
       }
     },
     "teeny-request": {
@@ -4379,21 +4927,16 @@
         "prepend-http": "^2.0.0"
       }
     },
-    "url-template": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
-    },
     "urlgrey": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
       "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
       "dev": true
     },
-    "uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "v8-compile-cache": {
       "version": "2.1.1",
@@ -4410,6 +4953,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "walkdir": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
+      "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ=="
     },
     "which": {
       "version": "1.3.1",
@@ -4430,7 +4978,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       },
@@ -4438,20 +4985,17 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -4461,7 +5005,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -4476,6 +5019,11 @@
       "requires": {
         "string-width": "^4.0.0"
       }
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
     },
     "word-wrap": {
       "version": "1.2.3",
@@ -4546,8 +5094,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/packages/opentelemetry-cloud-trace-exporter/package.json
+++ b/packages/opentelemetry-cloud-trace-exporter/package.json
@@ -51,6 +51,7 @@
     "typescript": "3.9.7"
   },
   "dependencies": {
+    "@grpc/grpc-js": "^1.0.5",
     "@grpc/proto-loader": "^0.5.4",
     "@opentelemetry/api": "^0.7.0",
     "@opentelemetry/base": "^0.7.0",
@@ -59,7 +60,6 @@
     "@opentelemetry/tracing": "^0.7.0",
     "google-auth-library": "^5.7.0",
     "google-proto-files": "^2.1.0",
-    "googleapis": "^46.0.0",
-    "grpc": "^1.24.3"
+    "googleapis": "^46.0.0"
   }
 }

--- a/packages/opentelemetry-cloud-trace-exporter/package.json
+++ b/packages/opentelemetry-cloud-trace-exporter/package.json
@@ -51,12 +51,15 @@
     "typescript": "3.9.7"
   },
   "dependencies": {
+    "@grpc/proto-loader": "^0.5.4",
     "@opentelemetry/api": "^0.7.0",
     "@opentelemetry/base": "^0.7.0",
     "@opentelemetry/core": "^0.7.0",
     "@opentelemetry/resources": "^0.7.0",
     "@opentelemetry/tracing": "^0.7.0",
     "google-auth-library": "^5.7.0",
-    "googleapis": "^46.0.0"
+    "google-proto-files": "^2.1.0",
+    "googleapis": "^46.0.0",
+    "grpc": "^1.24.3"
   }
 }

--- a/packages/opentelemetry-cloud-trace-exporter/package.json
+++ b/packages/opentelemetry-cloud-trace-exporter/package.json
@@ -51,7 +51,6 @@
     "typescript": "3.9.7"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.0.5",
     "@grpc/proto-loader": "^0.5.4",
     "@opentelemetry/api": "^0.7.0",
     "@opentelemetry/base": "^0.7.0",
@@ -60,6 +59,6 @@
     "@opentelemetry/tracing": "^0.7.0",
     "google-auth-library": "^5.7.0",
     "google-proto-files": "^2.1.0",
-    "googleapis": "^46.0.0"
+    "grpc": "^1.24.3"
   }
 }

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -102,7 +102,9 @@ export class TraceExporter implements SpanExporter {
 
     const metadata = new grpc.Metadata();
     metadata.add(OT_REQUEST_HEADER, '1');
-    const batchWriteSpans = promisify(this._traceServiceClient.BatchWriteSpans);
+    const batchWriteSpans = promisify(
+      this._traceServiceClient.BatchWriteSpans
+    ).bind(this._traceServiceClient);
     try {
       await batchWriteSpans(spans, metadata);
       const successMsg = 'batchWriteSpans successfully';
@@ -134,7 +136,7 @@ export class TraceExporter implements SpanExporter {
         oneofs: true,
       }
     );
-    /* tslint:disable-next-line:no-any */
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     const { google }: any = grpc.loadPackageDefinition(packageDefinition);
     const traceService = google.devtools.cloudtrace.v2.TraceService;
     const sslCreds = grpc.credentials.createSsl();

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -93,7 +93,7 @@ export class TraceExporter implements SpanExporter {
     try {
       this._traceServiceClient = await this._getClient();
     } catch (err) {
-      err.message = `authorize error: ${err.message}`;
+      err.message = `failed to create client: ${err.message}`;
       this._logger.error(err.message);
       return ExportResult.FAILED_NOT_RETRYABLE;
     }

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -14,12 +14,17 @@
 
 import { ExportResult } from '@opentelemetry/base';
 import { NoopLogger } from '@opentelemetry/core';
-import { ReadableSpan, SpanExporter  } from '@opentelemetry/tracing';
+import { ReadableSpan, SpanExporter } from '@opentelemetry/tracing';
 import { Logger } from '@opentelemetry/api';
 import * as protoloader from '@grpc/proto-loader';
 import * as protofiles from 'google-proto-files';
 import * as grpc from '@grpc/grpc-js';
-import { GoogleAuth, UserRefreshClient, JWT, Compute } from 'google-auth-library';
+import { 
+  GoogleAuth, 
+  UserRefreshClient, 
+  JWT, 
+  Compute 
+} from 'google-auth-library';
 import { TraceExporterOptions } from './external-types';
 import { getReadableSpanTransformer } from './transform';
 import { TraceService, NamedSpans } from './types';
@@ -66,7 +71,7 @@ export class TraceExporter implements SpanExporter {
     if (!this._projectId) {
       return resultCallback(ExportResult.FAILED_NOT_RETRYABLE);
     }
-    
+
     this._logger.debug('Google Cloud Trace export');
 
     if (!this._traceServiceClient) {
@@ -131,14 +136,19 @@ export class TraceExporter implements SpanExporter {
    */
   private _init(creds: Compute | JWT | UserRefreshClient): void {
     this._logger.debug('Google Cloud Trace initializing rpc client');
-    const pacakageDefinition = protoloader.loadSync(protofiles.getProtoPath('devtools', 'cloudtrace', 'v2', 'tracing.proto'), {
-      includeDirs: [protofiles.getProtoPath('..')],
-    });
+    const pacakageDefinition = protoloader.loadSync(
+      protofiles.getProtoPath('devtools', 'cloudtrace', 'v2', 'tracing.proto'), 
+      {
+        includeDirs: [protofiles.getProtoPath('..')],
+      }
+    );
     const { google }: any = grpc.loadPackageDefinition(pacakageDefinition);
     const traceService = google.devtools.cloudtrace.v2.TraceService;
     const sslCreds = grpc.credentials.createSsl();
     const callCreds = grpc.credentials.createFromGoogleCredential(creds);
-    this._traceServiceClient = 
-      new traceService('cloudtrace.googleapis.com:443', grpc.credentials.combineChannelCredentials(sslCreds, callCreds));
+    this._traceServiceClient = new traceService(
+        'cloudtrace.googleapis.com:443', 
+        grpc.credentials.combineChannelCredentials(sslCreds, callCreds)
+    );
   }
 }

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -24,6 +24,8 @@ import { TraceExporterOptions } from './external-types';
 import { getReadableSpanTransformer } from './transform';
 import { TraceService, NamedSpans } from './types';
 
+const OT_REQUEST_HEADER = 'x-opentelemetry-outgoing-request';
+
 /**
  * Format and sends span information to Google Cloud Trace.
  */
@@ -100,7 +102,7 @@ export class TraceExporter implements SpanExporter {
       }
 
       const metadata = new grpc.Metadata();
-      metadata.add('x-opentelemetry-outgoing-request', '1');
+      metadata.add(OT_REQUEST_HEADER, '1');
       this._traceServiceClient.BatchWriteSpans(
         spans,
         metadata,

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -90,14 +90,12 @@ export class TraceExporter implements SpanExporter {
    */
   private async _batchWriteSpans(spans: NamedSpans): Promise<ExportResult> {
     this._logger.debug('Google Cloud Trace batch writing traces');
-    if (!this._traceServiceClient) {
-      try {
-        this._traceServiceClient = await this._getClient();
-      } catch (err) {
-        err.message = `authorize error: ${err.message}`;
-        this._logger.error(err.message);
-        return ExportResult.FAILED_NOT_RETRYABLE;
-      }
+    try {
+      this._traceServiceClient = await this._getClient();
+    } catch (err) {
+      err.message = `authorize error: ${err.message}`;
+      this._logger.error(err.message);
+      return ExportResult.FAILED_NOT_RETRYABLE;
     }
 
     const metadata = new grpc.Metadata();
@@ -122,6 +120,9 @@ export class TraceExporter implements SpanExporter {
    * authenticates with google credentials and initializes the rpc client
    */
   private async _getClient(): Promise<TraceService> {
+    if (this._traceServiceClient) {
+      return this._traceServiceClient;
+    }
     this._logger.debug('Google Cloud Trace authenticating');
     const creds = await this._auth.getClient();
     this._logger.debug(

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -18,7 +18,7 @@ import { ReadableSpan, SpanExporter  } from '@opentelemetry/tracing';
 import { Logger } from '@opentelemetry/api';
 import * as protoloader from '@grpc/proto-loader';
 import * as protofiles from 'google-proto-files';
-import * as grpc from 'grpc';
+import * as grpc from '@grpc/grpc-js';
 import { GoogleAuth } from 'google-auth-library';
 import { TraceExporterOptions } from './external-types';
 import { getReadableSpanTransformer } from './transform';

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -101,7 +101,10 @@ export class TraceExporter implements SpanExporter {
 
       const metadata = new grpc.Metadata();
       metadata.add('x-opentelemetry-outgoing-request', '1');
-      this._traceServiceClient.BatchWriteSpans(spans, metadata, (err: Error) => {
+      this._traceServiceClient.BatchWriteSpans(
+        spans,
+        metadata,
+        (err: Error) => {
         if (err) {
           err.message = `batchWriteSpans error: ${err.message}`;
           this._logger.error(err.message);
@@ -111,7 +114,8 @@ export class TraceExporter implements SpanExporter {
           this._logger.debug(successMsg);
           resolve(ExportResult.SUCCESS);
         }
-      });
+      }
+      );
     });
   }
 

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -73,7 +73,7 @@ export class TraceExporter implements SpanExporter {
       name: `projects/${this._projectId}`,
       spans: spans.map(getReadableSpanTransformer(this._projectId)),
     };
-    
+
     try {
       const result = await this._batchWriteSpans(namedSpans);
       resultCallback(result);
@@ -94,7 +94,7 @@ export class TraceExporter implements SpanExporter {
   private _batchWriteSpans(spans: NamedSpans): Promise<ExportResult> {
     this._logger.debug('Google Cloud Trace batch writing traces');
     // Always resolve with the ExportResult code
-    return new Promise(async (resolve) => {
+    return new Promise(async resolve => {
       if (!this._traceServiceClient) {
         try {
           this._traceServiceClient = await this._getClient();

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -105,8 +105,7 @@ export class TraceExporter implements SpanExporter {
     ).bind(this._traceServiceClient);
     try {
       await batchWriteSpans(spans, metadata);
-      const successMsg = 'batchWriteSpans successfully';
-      this._logger.debug(successMsg);
+      this._logger.debug('batchWriteSpans successfully');
       return ExportResult.SUCCESS;
     } catch (err) {
       err.message = `batchWriteSpans error: ${err.message}`;

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -99,7 +99,9 @@ export class TraceExporter implements SpanExporter {
         }
       }
 
-      this._traceServiceClient.BatchWriteSpans(spans, (err: Error) => {
+      const metadata = new grpc.Metadata();
+      metadata.add('x-opentelemetry-outgoing-request', '1');
+      this._traceServiceClient.BatchWriteSpans(spans, metadata, (err: Error) => {
         if (err) {
           err.message = `batchWriteSpans error: ${err.message}`;
           this._logger.error(err.message);

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -123,14 +123,14 @@ export class TraceExporter implements SpanExporter {
     this._logger.debug(
       'Google Cloud Trace got authentication. Initializaing rpc client'
     );
-    const pacakageDefinition = protoloader.loadSync(
+    const packageDefinition = protoloader.loadSync(
       protofiles.getProtoPath('devtools', 'cloudtrace', 'v2', 'tracing.proto'),
       {
         includeDirs: [protofiles.getProtoPath('..')],
       }
     );
     /* tslint:disable-next-line:no-any */
-    const { google }: any = grpc.loadPackageDefinition(pacakageDefinition);
+    const { google }: any = grpc.loadPackageDefinition(packageDefinition);
     const traceService = google.devtools.cloudtrace.v2.TraceService;
     const sslCreds = grpc.credentials.createSsl();
     const callCreds = grpc.credentials.createFromGoogleCredential(creds);

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -20,10 +20,10 @@ import * as protoloader from '@grpc/proto-loader';
 import * as protofiles from 'google-proto-files';
 import * as grpc from '@grpc/grpc-js';
 import { 
-  GoogleAuth, 
-  UserRefreshClient, 
-  JWT, 
-  Compute 
+  GoogleAuth,
+  UserRefreshClient,
+  JWT,
+  Compute
 } from 'google-auth-library';
 import { TraceExporterOptions } from './external-types';
 import { getReadableSpanTransformer } from './transform';
@@ -137,7 +137,7 @@ export class TraceExporter implements SpanExporter {
   private _init(creds: Compute | JWT | UserRefreshClient): void {
     this._logger.debug('Google Cloud Trace initializing rpc client');
     const pacakageDefinition = protoloader.loadSync(
-      protofiles.getProtoPath('devtools', 'cloudtrace', 'v2', 'tracing.proto'), 
+      protofiles.getProtoPath('devtools', 'cloudtrace', 'v2', 'tracing.proto'),
       {
         includeDirs: [protofiles.getProtoPath('..')],
       }
@@ -147,8 +147,8 @@ export class TraceExporter implements SpanExporter {
     const sslCreds = grpc.credentials.createSsl();
     const callCreds = grpc.credentials.createFromGoogleCredential(creds);
     this._traceServiceClient = new traceService(
-        'cloudtrace.googleapis.com:443', 
-        grpc.credentials.combineChannelCredentials(sslCreds, callCreds)
+      'cloudtrace.googleapis.com:443',
+      grpc.credentials.combineChannelCredentials(sslCreds, callCreds)
     );
   }
 }

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -131,10 +131,13 @@ export class TraceExporter implements SpanExporter {
     this._logger.debug(
       'Google Cloud Trace got authentication. Initializaing rpc client'
     );
-    const packageDefinition = protoloader.loadSync(
+    const packageDefinition = await protoloader.load(
       protofiles.getProtoPath('devtools', 'cloudtrace', 'v2', 'tracing.proto'),
       {
         includeDirs: [protofiles.getProtoPath('..')],
+        longs: String,
+        defaults: true,
+        oneofs: true,
       }
     );
     /* tslint:disable-next-line:no-any */

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -20,13 +20,9 @@ import * as protoloader from '@grpc/proto-loader';
 import * as protofiles from 'google-proto-files';
 import * as grpc from 'grpc';
 import { GoogleAuth } from 'google-auth-library';
-import { google } from 'googleapis';
 import { TraceExporterOptions } from './external-types';
 import { getReadableSpanTransformer } from './transform';
-import { Span, SpansWithCredentials, TraceService } from './types';
-
-const OT_REQUEST_HEADER = 'x-opentelemetry-outgoing-request';
-google.options({ headers: { [OT_REQUEST_HEADER]: 1 } });
+import { TraceService, NamedSpans } from './types';
 
 /**
  * Format and sends span information to Google Cloud Trace.
@@ -53,21 +49,6 @@ export class TraceExporter implements SpanExporter {
     this._projectId = this._auth.getProjectId().catch(err => {
       this._logger.error(err);
     });
-
-    const pacakageDefinition = protoloader.loadSync(protofiles.getProtoPath('devtools', 'cloudtrace', 'v2', 'tracing.proto'), {
-      includeDirs: [protofiles.getProtoPath('..')],
-    });
-    const { google }: any = grpc.loadPackageDefinition(pacakageDefinition);
-    const traceService = google.devtools.cloudtrace.v2.TraceService;
-    this._auth.getApplicationDefault()
-      .then((creds) => {
-        const sslCreds = grpc.credentials.createSsl();
-        const callCreds = grpc.credentials.createFromGoogleCredential(creds.credential);
-        this._traceServiceClient = 
-          new traceService('cloudtrace.googleapis.com', grpc.credentials.combineChannelCredentials(sslCreds, callCreds));
-    })
-      .catch(this._logger.error);
-    this._traceServiceClient = new traceService('cloudtrace.googleapis.com', grpc.credentials.createInsecure());
   }
 
   /**
@@ -87,15 +68,22 @@ export class TraceExporter implements SpanExporter {
     }
     
     this._logger.debug('Google Cloud Trace export');
-    const authorizedSpans = await this._authorize(spans.map(getReadableSpanTransformer(this._projectId)));
 
-    if (!authorizedSpans) {
+    if (!this._traceServiceClient) {
+      await this._init();
+    }
+
+    const namedSpans: NamedSpans = {
+      name: `projects/${this._projectId}`,
+      spans: spans.map(getReadableSpanTransformer(this._projectId)),
+    };
+
+    if (!namedSpans) {
       return resultCallback(ExportResult.FAILED_NOT_RETRYABLE);
     }
-    this._logger.debug('Google Cloud Trace got span authorization');
 
     try {
-      await this._batchWriteSpans(authorizedSpans);
+      await this._batchWriteSpans(namedSpans);
       resultCallback(ExportResult.SUCCESS);
     } catch (err) {
       this._logger.error(`Google Cloud Trace failed to export ${err}`);
@@ -110,18 +98,13 @@ export class TraceExporter implements SpanExporter {
    * service.
    * @param spans
    */
-  private _batchWriteSpans(spans: SpansWithCredentials) {
+  private _batchWriteSpans(spans: NamedSpans) {
     this._logger.debug('Google Cloud Trace batch writing traces');
     return new Promise((resolve, reject) => {
       if (!this._traceServiceClient) {
         return reject(new Error('channel not yet opened'));
       }
-      // TODO: Add headers for authentication
-      const call = {
-        name: spans.name,
-        spans: spans.resource.spans,
-      };
-      this._traceServiceClient.BatchWriteSpans(call, (err: Error) => {
+      this._traceServiceClient.BatchWriteSpans(spans, (err: Error) => {
         if (err) {
           err.message = `batchWriteSpans error: ${err.message}`;
           this._logger.error(err.message);
@@ -136,23 +119,19 @@ export class TraceExporter implements SpanExporter {
   }
 
   /**
-   * Gets the Google Application Credentials from the environment variables,
-   * authenticates the client and calls a method to send the spans data.
-   * @param spans The spans to export
+   * Initializes the cloudtrace rpc client
    */
-  private async _authorize(
-    spans: Span[]
-  ): Promise<SpansWithCredentials | null> {
-    try {
-      return {
-        name: `projects/${this._projectId}`,
-        resource: { spans },
-        auth: await this._auth.getClient(),
-      };
-    } catch (err) {
-      err.message = `authorize error: ${err.message}`;
-      this._logger.error(err.message);
-      return null;
-    }
+  private async _init(): Promise<void> {
+    this._logger.debug('Google Cloud Trace initializing rpc client');
+    const pacakageDefinition = protoloader.loadSync(protofiles.getProtoPath('devtools', 'cloudtrace', 'v2', 'tracing.proto'), {
+      includeDirs: [protofiles.getProtoPath('..')],
+    });
+    const { google }: any = grpc.loadPackageDefinition(pacakageDefinition);
+    const traceService = google.devtools.cloudtrace.v2.TraceService;
+    const creds = await this._auth.getApplicationDefault();
+    const sslCreds = grpc.credentials.createSsl();
+    const callCreds = grpc.credentials.createFromGoogleCredential(creds.credential);
+    this._traceServiceClient = 
+      new traceService('cloudtrace.googleapis.com:443', grpc.credentials.combineChannelCredentials(sslCreds, callCreds));
   }
 }

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -74,14 +74,8 @@ export class TraceExporter implements SpanExporter {
       spans: spans.map(getReadableSpanTransformer(this._projectId)),
     };
 
-    try {
-      const result = await this._batchWriteSpans(namedSpans);
-      resultCallback(result);
-    } catch (err) {
-      err.message = `Google Cloud Trace failed to export ${err.message}`;
-      this._logger.error(err.message);
-      resultCallback(ExportResult.FAILED_NOT_RETRYABLE);
-    }
+    const result = await this._batchWriteSpans(namedSpans);
+    resultCallback(result);
   }
 
   shutdown(): void {}

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -105,16 +105,16 @@ export class TraceExporter implements SpanExporter {
         spans,
         metadata,
         (err: Error) => {
-        if (err) {
-          err.message = `batchWriteSpans error: ${err.message}`;
-          this._logger.error(err.message);
-          resolve(ExportResult.FAILED_RETRYABLE);
-        } else {
-          const successMsg = 'batchWriteSpans successfully';
-          this._logger.debug(successMsg);
-          resolve(ExportResult.SUCCESS);
+          if (err) {
+            err.message = `batchWriteSpans error: ${err.message}`;
+            this._logger.error(err.message);
+            resolve(ExportResult.FAILED_RETRYABLE);
+          } else {
+            const successMsg = 'batchWriteSpans successfully';
+            this._logger.debug(successMsg);
+            resolve(ExportResult.SUCCESS);
+          }
         }
-      }
       );
     });
   }

--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -52,11 +52,11 @@ export function getReadableSpanTransformer(
       links: {
         link: span.links.map(transformLink),
       },
-      endTime: hrTimeToTimeStamp(span.endTime),
-      startTime: hrTimeToTimeStamp(span.startTime),
+      endTime: new Date(hrTimeToTimeStamp(span.endTime)),
+      startTime: new Date(hrTimeToTimeStamp(span.startTime)),
       name: `projects/${projectId}/traces/${span.spanContext.traceId}/spans/${span.spanContext.spanId}`,
       spanId: span.spanContext.spanId,
-      sameProcessAsParentSpan: !span.spanContext.isRemote,
+      sameProcessAsParentSpan: new Boolean(!span.spanContext.isRemote),
       status: span.status,
       timeEvents: {
         timeEvent: span.events.map(e => ({

--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -27,7 +27,6 @@ import {
   TruncatableString,
 } from './types';
 import { VERSION } from './version';
-import { HrTime } from '@opentelemetry/api';
 
 const AGENT_LABEL_KEY = 'g.co/agent';
 const AGENT_LABEL_VALUE = `opentelemetry-js ${CORE_VERSION}; google-cloud-trace-exporter ${VERSION}`;
@@ -76,7 +75,7 @@ export function getReadableSpanTransformer(
   };
 }
 
-function transformTime(time: HrTime): Timestamp {
+function transformTime(time: ot.HrTime): Timestamp {
   return {
     seconds: time[0],
     nanos: time[1],

--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -22,7 +22,7 @@ import {
   AttributeValue,
   Link,
   LinkType,
-  Span, 
+  Span,
   Timestamp,
   TruncatableString,
 } from './types';

--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -15,7 +15,6 @@
 import * as ot from '@opentelemetry/api';
 import {
   VERSION as CORE_VERSION,
-  hrTimeToMilliseconds,
 } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
 import { ReadableSpan } from '@opentelemetry/tracing';
@@ -79,9 +78,9 @@ export function getReadableSpanTransformer(
 }
 
 function transformTime(time: HrTime): Timestamp {
-  const miliseconds = hrTimeToMilliseconds(time);
   return {
-    seconds: Math.floor(miliseconds / 1000),
+    seconds: time[0],
+    nanos: time[1],
   };
 }
 

--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -20,13 +20,13 @@ import {
 import { Resource } from '@opentelemetry/resources';
 import { ReadableSpan } from '@opentelemetry/tracing';
 import {
-    AttributeMap,
-    Attributes,
-    AttributeValue,
-    Link,
-    LinkType,
-    Span, Timestamp,
-    TruncatableString,
+  AttributeMap,
+  Attributes,
+  AttributeValue,
+  Link,
+  LinkType,
+  Span, Timestamp,
+  TruncatableString,
 } from './types';
 import { VERSION } from './version';
 import { HrTime } from '@opentelemetry/api';

--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 import * as ot from '@opentelemetry/api';
-import {
-  VERSION as CORE_VERSION,
-} from '@opentelemetry/core';
+import { VERSION as CORE_VERSION } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
 import { ReadableSpan } from '@opentelemetry/tracing';
 import {
@@ -24,7 +22,8 @@ import {
   AttributeValue,
   Link,
   LinkType,
-  Span, Timestamp,
+  Span, 
+  Timestamp,
   TruncatableString,
 } from './types';
 import { VERSION } from './version';
@@ -56,7 +55,7 @@ export function getReadableSpanTransformer(
       startTime: transformTime(span.startTime),
       name: `projects/${projectId}/traces/${span.spanContext.traceId}/spans/${span.spanContext.spanId}`,
       spanId: span.spanContext.spanId,
-      sameProcessAsParentSpan: {value: !span.spanContext.isRemote},
+      sameProcessAsParentSpan: { value: !span.spanContext.isRemote },
       status: span.status,
       timeEvents: {
         timeEvent: span.events.map(e => ({

--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -57,7 +57,7 @@ export function getReadableSpanTransformer(
       startTime: transformTime(span.startTime),
       name: `projects/${projectId}/traces/${span.spanContext.traceId}/spans/${span.spanContext.spanId}`,
       spanId: span.spanContext.spanId,
-      sameProcessAsParentSpan: new Boolean(!span.spanContext.isRemote),
+      sameProcessAsParentSpan: {value: !span.spanContext.isRemote},
       status: span.status,
       timeEvents: {
         timeEvent: span.events.map(e => ({

--- a/packages/opentelemetry-cloud-trace-exporter/src/types.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/types.ts
@@ -138,3 +138,14 @@ export interface SpansWithCredentials {
   resource: { spans: {} };
   auth: JWT | OAuth2Client | Compute;
 }
+
+export interface TraceService {
+  BatchWriteSpans: (call: any, callback: Function) => void;
+}
+
+export interface TraceServiceRequest {
+  name: string;
+  span: any[];
+}
+
+

--- a/packages/opentelemetry-cloud-trace-exporter/src/types.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/types.ts
@@ -26,7 +26,7 @@ export interface Span {
   timeEvents?: TimeEvents;
   links?: Links;
   status?: Status;
-  sameProcessAsParentSpan?: Boolean;
+  sameProcessAsParentSpan?: BoolValue;
   childSpanCount?: number;
 }
 
@@ -134,6 +134,13 @@ export enum LinkType {
   UNSPECIFIED = 0,
   CHILD_LINKED_SPAN = 1,
   PARENT_LINKED_SPAN = 2,
+}
+
+/**
+ * A protobuf boolean
+ */
+export interface BoolValue {
+  value: boolean;
 }
 
 export interface NamedSpans {

--- a/packages/opentelemetry-cloud-trace-exporter/src/types.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/types.ts
@@ -148,11 +148,6 @@ export interface NamedSpans {
   spans: Span[];
 }
 
-export interface TraceServiceRequest {
-  name: string;
-  spans: any[];
-}
-
 export interface TraceService {
-  BatchWriteSpans: (call: TraceServiceRequest, callback: Function) => void;
+  BatchWriteSpans: (call: NamedSpans, callback: Function) => void;
 }

--- a/packages/opentelemetry-cloud-trace-exporter/src/types.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/types.ts
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Compute, JWT, OAuth2Client } from 'google-auth-library';
-
 export interface Span {
   name?: string;
   spanId?: string;

--- a/packages/opentelemetry-cloud-trace-exporter/src/types.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/types.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Metadata } from 'grpc';
+
 export interface Span {
   name?: string;
   spanId?: string;
@@ -149,5 +151,5 @@ export interface NamedSpans {
 }
 
 export interface TraceService {
-  BatchWriteSpans: (call: NamedSpans, callback: Function) => void;
+  BatchWriteSpans: (call: NamedSpans, metadata: Metadata, callback: Function) => void;
 }

--- a/packages/opentelemetry-cloud-trace-exporter/src/types.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/types.ts
@@ -151,5 +151,9 @@ export interface NamedSpans {
 }
 
 export interface TraceService {
-  BatchWriteSpans: (call: NamedSpans, metadata: Metadata, callback: Function) => void;
+  BatchWriteSpans: (
+    call: NamedSpans,
+    metadata: Metadata,
+    callback: Function
+  ) => void;
 }

--- a/packages/opentelemetry-cloud-trace-exporter/src/types.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/types.ts
@@ -19,8 +19,8 @@ export interface Span {
   spanId?: string;
   parentSpanId?: string;
   displayName?: TruncatableString;
-  startTime?: string;
-  endTime?: string;
+  startTime?: Date;
+  endTime?: Date;
   attributes?: Attributes;
   // This property is currently unused. keeping it here as it is part
   // of the stack driver trace types and may be used in the future
@@ -28,7 +28,7 @@ export interface Span {
   timeEvents?: TimeEvents;
   links?: Links;
   status?: Status;
-  sameProcessAsParentSpan?: boolean;
+  sameProcessAsParentSpan?: Boolean;
   childSpanCount?: number;
 }
 

--- a/packages/opentelemetry-cloud-trace-exporter/src/types.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/types.ts
@@ -33,8 +33,8 @@ export interface Span {
 }
 
 export interface Timestamp {
-  seconds?: number;
-  nanos?: number;
+  seconds: number;
+  nanos: number;
 }
 
 export interface AttributeMap {

--- a/packages/opentelemetry-cloud-trace-exporter/src/types.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/types.ts
@@ -19,8 +19,8 @@ export interface Span {
   spanId?: string;
   parentSpanId?: string;
   displayName?: TruncatableString;
-  startTime?: Date;
-  endTime?: Date;
+  startTime?: Timestamp;
+  endTime?: Timestamp;
   attributes?: Attributes;
   // This property is currently unused. keeping it here as it is part
   // of the stack driver trace types and may be used in the future
@@ -30,6 +30,11 @@ export interface Span {
   status?: Status;
   sameProcessAsParentSpan?: Boolean;
   childSpanCount?: number;
+}
+
+export interface Timestamp {
+    seconds?: number;
+    nanos?: number;
 }
 
 export interface AttributeMap {
@@ -103,7 +108,7 @@ export interface TimeEvents {
 
 export interface TimeEvent {
   annotation?: Annotation;
-  time?: string;
+  time?: Timestamp;
   // This property is currently unused. keeping it here as it is part
   // of the stack driver trace types and may be used in the future
   messageEvent?: MessageEvent;
@@ -133,19 +138,17 @@ export enum LinkType {
   PARENT_LINKED_SPAN = 2,
 }
 
-export interface SpansWithCredentials {
+export interface NamedSpans {
   name: string;
-  resource: { spans: {} };
-  auth: JWT | OAuth2Client | Compute;
-}
-
-export interface TraceService {
-  BatchWriteSpans: (call: any, callback: Function) => void;
+  spans: Span[];
 }
 
 export interface TraceServiceRequest {
   name: string;
-  span: any[];
+  spans: any[];
 }
 
+export interface TraceService {
+  BatchWriteSpans: (call: TraceServiceRequest, callback: Function) => void;
+}
 

--- a/packages/opentelemetry-cloud-trace-exporter/src/types.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/types.ts
@@ -31,8 +31,8 @@ export interface Span {
 }
 
 export interface Timestamp {
-    seconds?: number;
-    nanos?: number;
+  seconds?: number;
+  nanos?: number;
 }
 
 export interface AttributeMap {
@@ -156,4 +156,3 @@ export interface TraceServiceRequest {
 export interface TraceService {
   BatchWriteSpans: (call: TraceServiceRequest, callback: Function) => void;
 }
-

--- a/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
@@ -75,12 +75,11 @@ describe('Google Cloud Trace Exporter', () => {
         }
       );
 
-      sinon.replace(
-        exporter, <any>'_init', (creds: any) => {
-          exporter['_traceServiceClient'] = {
-            BatchWriteSpans: batchWrite,
-          };
-          return Promise.resolve();
+      sinon.replace(exporter, <any>'_init', (creds: any) => {
+        exporter['_traceServiceClient'] = {
+          BatchWriteSpans: batchWrite,
+        };
+        return Promise.resolve();
         }
       );
 

--- a/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
@@ -76,10 +76,14 @@ describe('Google Cloud Trace Exporter', () => {
       );
 
       sinon.replace(
-        TraceExporter['_cloudTrace'].projects.traces,
-        'batchWrite',
-        /* tslint:disable-next-line:no-any */
-        batchWrite as any
+        exporter,
+        <any>'_init',
+        (creds: any) => {
+          exporter['_traceServiceClient'] = {
+            BatchWriteSpans: batchWrite,
+          };
+          return Promise.resolve();
+        }
       );
 
       sinon.replace(exporter['_auth'], 'getClient', () => {
@@ -133,7 +137,7 @@ describe('Google Cloud Trace Exporter', () => {
       });
 
       assert.deepStrictEqual(
-        batchWrite.getCall(0).args[0].resource.spans[0].displayName.value,
+        batchWrite.getCall(0).args[0].spans[0].displayName.value,
         'my-span'
       );
 
@@ -168,7 +172,6 @@ describe('Google Cloud Trace Exporter', () => {
           resolve(result);
         });
       });
-
       assert(batchWrite.notCalled);
       assert(error.getCall(0).args[0].match(/authorize error: fail/));
       assert.deepStrictEqual(result, ExportResult.FAILED_NOT_RETRYABLE);
@@ -202,7 +205,6 @@ describe('Google Cloud Trace Exporter', () => {
           resolve(result);
         });
       });
-
       assert.deepStrictEqual(result, ExportResult.FAILED_RETRYABLE);
     });
 

--- a/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
@@ -44,6 +44,22 @@ describe('Google Cloud Trace Exporter', () => {
     });
   });
 
+  describe('_init', () => {
+    it('should create the rpc client', async () => {
+      const exporter = new TraceExporter({
+        credentials: {
+          client_email: 'noreply@fake.example.com',
+          private_key: 'this is a key',
+        },
+      });
+
+      const creds = await exporter['_auth'].getClient();
+      exporter['_init'](creds);
+
+      assert(exporter['_traceServiceClient']);
+    });
+  });
+
   describe('export', () => {
     let exporter: TraceExporter;
     let logger: ConsoleLogger;

--- a/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
@@ -75,7 +75,7 @@ describe('Google Cloud Trace Exporter', () => {
           metadata: any,
           callback: (err: Error | null) => void
         ): any => {
-        /* tslint:enable:no-any */
+          /* tslint:enable:no-any */
           if (batchWriteShouldFail) {
             callback(new Error('fail'));
           } else {
@@ -107,9 +107,9 @@ describe('Google Cloud Trace Exporter', () => {
               devtools: {
                 cloudtrace: {
                   v2: {},
-                }
-              }
-            }
+                },
+              },
+            },
           };
           // Replace the TraceService with a mock TraceService
           def.google.devtools.cloudtrace.v2.TraceService = class MockTraceService

--- a/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
@@ -24,7 +24,7 @@ import * as sinon from 'sinon';
 import * as protoloader from '@grpc/proto-loader';
 import * as grpc from 'grpc';
 import { TraceExporter } from '../src';
-import { TraceService } from '../src/types'
+import { TraceService } from '../src/types';
 
 describe('Google Cloud Trace Exporter', () => {
   beforeEach(() => {
@@ -69,8 +69,13 @@ describe('Google Cloud Trace Exporter', () => {
       });
 
       batchWrite = sinon.spy(
-        /* tslint:disable-next-line:no-any */
-        (spans: any, metadata: any, callback: (err: Error | null) => void): any => {
+        /* tslint:disable:no-any */
+        (
+          spans: any,
+          metadata: any,
+          callback: (err: Error | null) => void
+        ): any => {
+        /* tslint:enable:no-any */
           if (batchWriteShouldFail) {
             callback(new Error('fail'));
           } else {
@@ -87,31 +92,37 @@ describe('Google Cloud Trace Exporter', () => {
         return {} as any;
       });
 
-      sinon.stub(protoloader, "loadSync");
+      sinon.stub(protoloader, 'loadSync');
 
-      sinon.replace(grpc, 'loadPackageDefinition', (): grpc.GrpcObject => {
-        traceServiceConstructor =
-          sinon.spy((host: string, creds: grpc.ChannelCredentials) => {});
-        /* tslint:disable-next-line:no-any */
-        const def: any = {
-          google: {
-            devtools: {
-              cloudtrace: {
-                v2: {},
+      sinon.replace(
+        grpc,
+        'loadPackageDefinition',
+        (): grpc.GrpcObject => {
+          traceServiceConstructor = sinon.spy(
+            (host: string, creds: grpc.ChannelCredentials) => {}
+          );
+          /* tslint:disable-next-line:no-any */
+          const def: any = {
+            google: {
+              devtools: {
+                cloudtrace: {
+                  v2: {},
+                }
               }
             }
-          }
-        };
-        // Replace the TraceService with a mock TraceService
-        def.google.devtools.cloudtrace.v2.TraceService =
-          class MockTraceService implements TraceService {
+          };
+          // Replace the TraceService with a mock TraceService
+          def.google.devtools.cloudtrace.v2.TraceService = class MockTraceService
+            implements TraceService {
+            /* tslint:disable-next-line */
             BatchWriteSpans = batchWrite;
             constructor(host: string, creds: grpc.ChannelCredentials) {
               traceServiceConstructor(host, creds);
             }
           };
-        return def;
-      });
+          return def;
+        }
+      );
 
       debug = sinon.spy();
       info = sinon.spy();
@@ -160,7 +171,10 @@ describe('Google Cloud Trace Exporter', () => {
         'my-span'
       );
       assert.strictEqual(traceServiceConstructor.getCalls().length, 1);
-      assert.strictEqual(traceServiceConstructor.getCall(0).args[0], 'cloudtrace.googleapis.com:443');
+      assert.strictEqual(
+        traceServiceConstructor.getCall(0).args[0],
+        'cloudtrace.googleapis.com:443'
+      );
       assert.deepStrictEqual(result, ExportResult.SUCCESS);
     });
 
@@ -197,9 +211,8 @@ describe('Google Cloud Trace Exporter', () => {
         });
       });
 
-
       assert.strictEqual(traceServiceConstructor.getCalls().length, 1);
-    })
+    });
 
     it('should return not retryable if authorization fails', async () => {
       const readableSpan: ReadableSpan = {
@@ -230,7 +243,7 @@ describe('Google Cloud Trace Exporter', () => {
         });
       });
       assert(error.getCall(0).args[0].match(/authorize error: fail/));
-      assert.strictEqual(traceServiceConstructor.getCalls().length, 1)
+      assert.strictEqual(traceServiceConstructor.getCalls().length, 1);
       assert.deepStrictEqual(result, ExportResult.FAILED_NOT_RETRYABLE);
     });
 

--- a/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
@@ -76,9 +76,7 @@ describe('Google Cloud Trace Exporter', () => {
       );
 
       sinon.replace(
-        exporter,
-        <any>'_init',
-        (creds: any) => {
+        exporter, <any>'_init', (creds: any) => {
           exporter['_traceServiceClient'] = {
             BatchWriteSpans: batchWrite,
           };

--- a/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
@@ -283,7 +283,7 @@ describe('Google Cloud Trace Exporter', () => {
           resolve(result);
         });
       });
-      assert(error.getCall(0).args[0].match(/authorize error: fail/));
+      assert(error.getCall(0).args[0].match(/failed to create client: fail/));
       assert(traceServiceConstructor.calledOnce);
       assert.deepStrictEqual(result, ExportResult.FAILED_NOT_RETRYABLE);
     });

--- a/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
@@ -91,13 +91,13 @@ describe('Google Cloud Trace Exporter', () => {
         }
       );
 
-      sinon.replace(exporter, <any>'_init', (creds: any) => {
+      /* tslint:disable-next-line:no-any */
+      sinon.replace(exporter, '_init' as any, (creds: any) => {
         exporter['_traceServiceClient'] = {
           BatchWriteSpans: batchWrite,
         };
         return Promise.resolve();
-        }
-      );
+      });
 
       sinon.replace(exporter['_auth'], 'getClient', () => {
         if (getClientShouldFail) {

--- a/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
@@ -51,7 +51,7 @@ describe('Google Cloud Trace Exporter', () => {
     let exporter: TraceExporter;
     let logger: ConsoleLogger;
     /* tslint:disable-next-line:no-any */
-    let batchWrite: sinon.SinonSpy<[any, any], any>;
+    let batchWrite: sinon.SinonSpy<[any, any, any], any>;
     let traceServiceConstructor: sinon.SinonSpy;
     let debug: sinon.SinonSpy;
     let info: sinon.SinonSpy;
@@ -70,7 +70,7 @@ describe('Google Cloud Trace Exporter', () => {
 
       batchWrite = sinon.spy(
         /* tslint:disable-next-line:no-any */
-        (spans: any, callback: (err: Error | null) => void): any => {
+        (spans: any, metadata: any, callback: (err: Error | null) => void): any => {
           if (batchWriteShouldFail) {
             callback(new Error('fail'));
           } else {

--- a/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
@@ -110,13 +110,16 @@ describe('Google Cloud Trace Exporter', () => {
 
       sinon.stub(protoloader, 'loadSync');
 
-      createSsl = sinon.stub(grpc.credentials, 'createSsl')
+      createSsl = sinon
+        .stub(grpc.credentials, 'createSsl')
         .returns(mockChannelCreds);
 
-      createFromGoogleCreds = sinon.stub(grpc.credentials, 'createFromGoogleCredential')
+      createFromGoogleCreds = sinon
+        .stub(grpc.credentials, 'createFromGoogleCredential')
         .returns(mockCallCreds);
 
-      combineChannelCreds = sinon.stub(grpc.credentials, 'combineChannelCredentials')
+      combineChannelCreds = sinon
+        .stub(grpc.credentials, 'combineChannelCredentials')
         .returns(mockCombinedCreds);
 
       sinon.replace(
@@ -198,7 +201,12 @@ describe('Google Cloud Trace Exporter', () => {
 
       assert(createSsl.calledOnceWithExactly());
       assert(createFromGoogleCreds.calledOnceWithExactly(mockClient));
-      assert(combineChannelCreds.calledOnceWithExactly(mockChannelCreds, mockCallCreds));
+      assert(
+        combineChannelCreds.calledOnceWithExactly(
+          mockChannelCreds,
+          mockCallCreds
+        )
+      );
       assert(
         traceServiceConstructor.calledOnceWithExactly(
           'cloudtrace.googleapis.com:443',

--- a/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
@@ -76,14 +76,14 @@ describe('transform', () => {
       },
       displayName: { value: 'my-span' },
       links: { link: [] },
-      endTime: {seconds: 1566156731, nanos: 709},
-      startTime: {seconds: 1566156729, nanos: 709},
+      endTime: { seconds: 1566156731, nanos: 709 },
+      startTime: { seconds: 1566156729, nanos: 709 },
       name:
         'projects/project-id/traces/d4cda95b652f4a1592b449d5929fda1b/spans/6e0c63257de34c92',
       spanId: '6e0c63257de34c92',
       status: { code: 0 },
       timeEvents: { timeEvent: [] },
-      sameProcessAsParentSpan: {value: false},
+      sameProcessAsParentSpan: { value: false },
     });
   });
   it('should transform spans with parent', () => {
@@ -100,13 +100,13 @@ describe('transform', () => {
 
   it('should transform remote spans', () => {
     const remote = transformer(readableSpan);
-    assert.deepStrictEqual(remote.sameProcessAsParentSpan, {value: false});
+    assert.deepStrictEqual(remote.sameProcessAsParentSpan, { value: false });
   });
 
   it('should transform local spans', () => {
     readableSpan.spanContext.isRemote = false;
     const local = transformer(readableSpan);
-    assert.deepStrictEqual(local.sameProcessAsParentSpan, {value: true});
+    assert.deepStrictEqual(local.sameProcessAsParentSpan, { value: true });
   });
 
   it('should transform attributes', () => {
@@ -218,7 +218,7 @@ describe('transform', () => {
               value: 'something happened',
             },
           },
-          time: {seconds: 1566156729, nanos: 809},
+          time: { seconds: 1566156729, nanos: 809 },
         },
       ],
     });

--- a/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
@@ -76,8 +76,8 @@ describe('transform', () => {
       },
       displayName: { value: 'my-span' },
       links: { link: [] },
-      endTime: {seconds: 1566156731},
-      startTime: {seconds: 1566156729},
+      endTime: {seconds: 1566156731, nanos: 709},
+      startTime: {seconds: 1566156729, nanos: 709},
       name:
         'projects/project-id/traces/d4cda95b652f4a1592b449d5929fda1b/spans/6e0c63257de34c92',
       spanId: '6e0c63257de34c92',
@@ -218,7 +218,7 @@ describe('transform', () => {
               value: 'something happened',
             },
           },
-          time: {seconds: 1566156729},
+          time: {seconds: 1566156729, nanos: 809},
         },
       ],
     });
@@ -252,7 +252,7 @@ describe('transform', () => {
               value: 'something happened',
             },
           },
-          time: {seconds: 1566156729},
+          time: {seconds: 1566156729, nanos: 809},
         },
       ],
     });

--- a/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
@@ -252,7 +252,7 @@ describe('transform', () => {
               value: 'something happened',
             },
           },
-          time: {seconds: 1566156729, nanos: 809},
+          time: { seconds: 1566156729, nanos: 809 },
         },
       ],
     });

--- a/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
@@ -76,14 +76,14 @@ describe('transform', () => {
       },
       displayName: { value: 'my-span' },
       links: { link: [] },
-      endTime: '2019-08-18T19:32:11.000000709Z',
-      startTime: '2019-08-18T19:32:09.000000709Z',
+      endTime: {seconds: 1566156731},
+      startTime: {seconds: 1566156729},
       name:
         'projects/project-id/traces/d4cda95b652f4a1592b449d5929fda1b/spans/6e0c63257de34c92',
       spanId: '6e0c63257de34c92',
       status: { code: 0 },
       timeEvents: { timeEvent: [] },
-      sameProcessAsParentSpan: false,
+      sameProcessAsParentSpan: {value: false},
     });
   });
   it('should transform spans with parent', () => {
@@ -100,13 +100,13 @@ describe('transform', () => {
 
   it('should transform remote spans', () => {
     const remote = transformer(readableSpan);
-    assert.deepStrictEqual(remote.sameProcessAsParentSpan, false);
+    assert.deepStrictEqual(remote.sameProcessAsParentSpan, {value: false});
   });
 
   it('should transform local spans', () => {
     readableSpan.spanContext.isRemote = false;
     const local = transformer(readableSpan);
-    assert.deepStrictEqual(local.sameProcessAsParentSpan, true);
+    assert.deepStrictEqual(local.sameProcessAsParentSpan, {value: true});
   });
 
   it('should transform attributes', () => {
@@ -218,7 +218,7 @@ describe('transform', () => {
               value: 'something happened',
             },
           },
-          time: '2019-08-18T19:32:09.000000809Z',
+          time: {seconds: 1566156729},
         },
       ],
     });
@@ -252,7 +252,7 @@ describe('transform', () => {
               value: 'something happened',
             },
           },
-          time: '2019-08-18T19:32:09.000000809Z',
+          time: {seconds: 1566156729},
         },
       ],
     });


### PR DESCRIPTION
**Description**
- Adds a `cloudtrace.v2.TraceService` client to `TraceExporter` to be used to write span data to cloud trace
- Updated tests to work with the new rpc client

**Testing** 
- Passes existing unit tests
- Ran the following opentelemetry example found [here](https://github.com/open-telemetry/opentelemetry-js/tree/master/examples/grpc) modified to use the exporter in this PR, and it produced expected results
- Tested on a live instance

**Relevant Info**
- Docs for RPC service can be found [here](https://cloud.google.com/trace/docs/reference/v2/rpc/google.devtools.cloudtrace.v2#google.devtools.cloudtrace.v2.TraceService.BatchWriteSpans)

Fixes #94 