### PR TITLE
fix: add local linting via gts [WIP]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ unit_tests: &unit_tests
         command: npx lerna bootstrap --no-ci
     - run:
         name: Unit tests
-        command: npm run test
+        command: lerna run test
     - run:
         name: report coverage
         command: if [ "${CIRCLE_NODE_VERSION}" = "v12" ]; then npm run codecov; fi

--- a/package.json
+++ b/package.json
@@ -5,12 +5,17 @@
     "clean": "lerna run clean",
     "postinstall": "npm run bootstrap",
     "precompile": "tsc --version",
-    "compile": "lerna run compile",
+    "compile": "tsc -p .",
     "codecov": "lerna run codecov",
     "test": "lerna run test",
     "bootstrap": "lerna bootstrap",
     "lint": "lerna run lint",
-    "lint:fix": "lerna run lint:fix"
+    "lint:fix": "lerna run lint:fix",
+    "check": "gts check",
+    "fix": "gts fix",
+    "prepare": "npm run compile",
+    "pretest": "npm run compile",
+    "posttest": "npm run check"
   },
   "repository": "GoogleCloudPlatform/opentelemetry-operations-js",
   "keywords": [
@@ -29,6 +34,9 @@
     "node": ">=8.0.0"
   },
   "devDependencies": {
-    "lerna": "3.22.1"
+    "lerna": "3.22.1",
+    "gts": "^1.1.0",
+    "typescript": "~3.5.0",
+    "@types/node": "^10.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "codecov": "lerna run codecov",
     "test": "lerna run test",
     "bootstrap": "lerna bootstrap",
-    "lint": "lerna run lint",
+    "lint": "gts check",
     "lint:fix": "lerna run lint:fix",
     "check": "gts check",
     "fix": "gts fix",

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
@@ -161,8 +161,8 @@ describe('MetricExporter', () => {
         'custom.googleapis.com/opentelemetry/name'
       );
 
-      assert.equal(metricDescriptors.callCount, 1);
-      assert.equal(timeSeries.callCount, 1);
+      assert.strictEqual(metricDescriptors.callCount, 1);
+      assert.strictEqual(timeSeries.callCount, 1);
 
       assert.deepStrictEqual(result, ExportResult.SUCCESS);
     });
@@ -201,8 +201,8 @@ describe('MetricExporter', () => {
         'custom.googleapis.com/opentelemetry/name0'
       );
 
-      assert.equal(metricDescriptors.callCount, 401);
-      assert.equal(timeSeries.callCount, 3);
+      assert.strictEqual(metricDescriptors.callCount, 401);
+      assert.strictEqual(timeSeries.callCount, 3);
 
       assert.deepStrictEqual(result, ExportResult.SUCCESS);
     });

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'es5',
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "outDir": "build"
   },
   "include": [
-    "src/**/*.ts",
-    "test/**/*.ts"
+    "packages/**/*.ts",
   ]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "gts/tslint.json",
+  "linterOptions": {
+    "exclude": [
+      "**/*.json"
+    ]
+  }
+}


### PR DESCRIPTION
Adding gts version 1.1.0 for local linting.

Ran `npx gts init` and updated `tsconfig.json` to point to `packages` directory.

Fixes #https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/84