### PR TITLE
fix: cloud monitoring incompatibility with opentelemetry/metrics 0.9.0

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/package.json
+++ b/packages/opentelemetry-cloud-monitoring-exporter/package.json
@@ -54,7 +54,7 @@
     "@opentelemetry/api": "^0.7.0",
     "@opentelemetry/base": "^0.7.0",
     "@opentelemetry/core": "^0.7.0",
-    "@opentelemetry/metrics": "^0.6.1",
+    "@opentelemetry/metrics": "^0.9.0",
     "google-auth-library": "^5.7.0",
     "googleapis": "^46.0.0"
   }

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
@@ -117,7 +117,7 @@ export class MetricExporter implements IMetricExporter {
       }
     }
 
-    let sendFailed: Error | undefined;
+    let sendFailed = false;
     for (const batchedTimeSeries of partitionList(
       timeSeries,
       MAX_BATCH_EXPORT_SIZE
@@ -125,9 +125,9 @@ export class MetricExporter implements IMetricExporter {
       try {
         await this._sendTimeSeries(batchedTimeSeries);
       } catch (err) {
-        err.message = `Send TimeSeries failed: ${err.message}`;
-        sendFailed = err;
-        this._logger.error(err.message);
+        const message = `Send TimeSeries failed: ${err.message}`;
+        sendFailed = true;
+        this._logger.error(message);
       }
     }
     if (sendFailed) {

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -24,7 +24,6 @@ import { ValueType as OTValueType } from '@opentelemetry/api';
 import {
   MetricDescriptor,
   MetricKind,
-  LabelDescriptor,
   ValueType,
   TimeSeries,
   Point,

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -68,11 +68,11 @@ function transformDisplayName(displayNamePrefix: string, name: string): string {
 function transformMetricKind(kind: OTMetricKind): MetricKind {
   switch (kind) {
     case OTMetricKind.COUNTER:
-    case OTMetricKind.SUM_OBSERVER:
-      return MetricKind.CUMULATIVE;
     case OTMetricKind.UP_DOWN_COUNTER:
+      return MetricKind.CUMULATIVE;
     // OTMetricKind.OBSERVER will be removed in opentelemetry-js #1146
     case OTMetricKind.OBSERVER:
+    case OTMetricKind.SUM_OBSERVER:
     case OTMetricKind.VALUE_OBSERVER:
     case OTMetricKind.UP_DOWN_SUM_OBSERVER:
       return MetricKind.GAUGE;
@@ -139,21 +139,24 @@ function transformPoint(
   // TODO: Add endTime and startTime support, once available in OpenTelemetry
   // Related issues: https://github.com/open-telemetry/opentelemetry-js/pull/893
   // and https://github.com/open-telemetry/opentelemetry-js/issues/488
-  if (metricDescriptor.metricKind === OTMetricKind.COUNTER) {
-    return {
-      value: transformValue(metricDescriptor.valueType, point.value),
-      interval: {
-        startTime,
-        endTime: new Date().toISOString(),
-      },
-    };
+  switch (metricDescriptor.metricKind) {
+    case OTMetricKind.COUNTER:
+    case OTMetricKind.UP_DOWN_COUNTER:
+      return {
+        value: transformValue(metricDescriptor.valueType, point.value),
+        interval: {
+          startTime,
+          endTime: new Date().toISOString(),
+        },
+      };
+    default:
+      return {
+        value: transformValue(metricDescriptor.valueType, point.value),
+        interval: {
+          endTime: new Date().toISOString(),
+        },
+      };
   }
-  return {
-    value: transformValue(metricDescriptor.valueType, point.value),
-    interval: {
-      endTime: new Date().toISOString(),
-    },
-  };
 }
 
 /** Transforms a OpenTelemetry Point's value to a StackDriver Point value. */

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -185,12 +185,16 @@ function transformValue(
 }
 
 /** Returns true if value is of type OTDistribution */
-function isDistributionValue(value: number | OTDistribution | OTHistogram): value is OTDistribution {
+function isDistributionValue(
+  value: number | OTDistribution | OTHistogram
+): value is OTDistribution {
   return value.hasOwnProperty('min');
 }
 
 /** Returns true if value is of type OTHistogram */
-function isHistogramValue(value: number | OTDistribution | OTHistogram): value is OTHistogram {
+function isHistogramValue(
+  value: number | OTDistribution | OTHistogram
+): value is OTHistogram {
   return value.hasOwnProperty('buckets');
 }
 

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -177,20 +177,20 @@ function transformValue(
   }
 
   if (valueType === OTValueType.INT) {
-    return { int64Value: value as number };
+    return { int64Value: value };
   } else if (valueType === OTValueType.DOUBLE) {
-    return { doubleValue: value as number };
+    return { doubleValue: value };
   }
   throw Error(`unsupported value type: ${valueType}`);
 }
 
 /** Returns true if value is of type OTDistribution */
-function isDistributionValue(value: number | OTDistribution | OTHistogram) {
+function isDistributionValue(value: number | OTDistribution | OTHistogram): value is OTDistribution {
   return value.hasOwnProperty('min');
 }
 
 /** Returns true if value is of type OTHistogram */
-function isHistogramValue(value: number | OTDistribution | OTHistogram) {
+function isHistogramValue(value: number | OTDistribution | OTHistogram): value is OTHistogram {
   return value.hasOwnProperty('buckets');
 }
 

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -125,8 +125,7 @@ function transformMetric(
   const labels: { [key: string]: string } = {};
 
   Object.keys(metric.labels).forEach(
-    key => labels[key] = `${metric.labels[key]}`
-  );
+    key => labels[key] = `${metric.labels[key]}`);
   labels[OPENTELEMETRY_TASK] = OPENTELEMETRY_TASK_VALUE_DEFAULT;
   return { type, labels };
 }

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -47,10 +47,12 @@ export function transformMetricDescriptor(
     metricKind: transformMetricKind(metricDescriptor.metricKind),
     valueType: transformValueType(metricDescriptor.valueType),
     unit: metricDescriptor.unit,
-    labels: [{
-      key: OPENTELEMETRY_TASK,
-      description: OPENTELEMETRY_TASK_DESCRIPTION,
-    }],
+    labels: [
+      {
+        key: OPENTELEMETRY_TASK,
+        description: OPENTELEMETRY_TASK_DESCRIPTION,
+      },
+    ],
   };
 }
 
@@ -122,8 +124,9 @@ function transformMetric(
   const type = transformMetricType(metricPrefix, metric.descriptor.name);
   const labels: { [key: string]: string } = {};
 
-  Object.keys(metric.labels)
-    .forEach(key => labels[key] = `${metric.labels[key]}`);
+  Object.keys(metric.labels).forEach(
+    key => labels[key] = `${metric.labels[key]}`
+  );
   labels[OPENTELEMETRY_TASK] = OPENTELEMETRY_TASK_VALUE_DEFAULT;
   return { type, labels };
 }

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -68,11 +68,11 @@ function transformDisplayName(displayNamePrefix: string, name: string): string {
 function transformMetricKind(kind: OTMetricKind): MetricKind {
   switch (kind) {
     case OTMetricKind.COUNTER:
-    case OTMetricKind.UP_DOWN_COUNTER:
+    case OTMetricKind.SUM_OBSERVER:
       return MetricKind.CUMULATIVE;
     // OTMetricKind.OBSERVER will be removed in opentelemetry-js #1146
     case OTMetricKind.OBSERVER:
-    case OTMetricKind.SUM_OBSERVER:
+    case OTMetricKind.UP_DOWN_COUNTER:
     case OTMetricKind.VALUE_OBSERVER:
     case OTMetricKind.UP_DOWN_SUM_OBSERVER:
       return MetricKind.GAUGE;
@@ -141,7 +141,7 @@ function transformPoint(
   // and https://github.com/open-telemetry/opentelemetry-js/issues/488
   switch (metricDescriptor.metricKind) {
     case OTMetricKind.COUNTER:
-    case OTMetricKind.UP_DOWN_COUNTER:
+    case OTMetricKind.SUM_OBSERVER:
       return {
         value: transformValue(metricDescriptor.valueType, point.value),
         interval: {

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -125,7 +125,8 @@ function transformMetric(
   const labels: { [key: string]: string } = {};
 
   Object.keys(metric.labels).forEach(
-    key => labels[key] = `${metric.labels[key]}`);
+    key => (labels[key] = `${metric.labels[key]}`)
+  );
   labels[OPENTELEMETRY_TASK] = OPENTELEMETRY_TASK_VALUE_DEFAULT;
   return { type, labels };
 }

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -164,14 +164,31 @@ function transformValue(
   valueType: OTValueType,
   value: number | OTDistribution | OTHistogram
 ) {
+  if (isDistributionValue(value)) {
+    // TODO: Add support for Distribution
+    throw new Error('Distributions are not yet supported');
+  }
+  if (isHistogramValue(value)) {
+    // TODO: Add support for Histogram
+    throw new Error('Histograms are not yet supported');
+  }
+
   if (valueType === OTValueType.INT) {
     return { int64Value: value as number };
   } else if (valueType === OTValueType.DOUBLE) {
     return { doubleValue: value as number };
   }
-  // TODO: Add support for Distribution
-  // TODO: Add support for Histogram
   throw Error(`unsupported value type: ${valueType}`);
+}
+
+/** Returns true if value is of type OTDistribution */
+function isDistributionValue(value: number | OTDistribution | OTHistogram) {
+  return value.hasOwnProperty('min');
+}
+
+/** Returns true if value is of type OTHistogram */
+function isHistogramValue(value: number | OTDistribution | OTHistogram) {
+  return value.hasOwnProperty('buckets');
 }
 
 /** Returns a task label value in the format of 'nodejs-<pid>@<hostname>'. */

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
@@ -144,10 +144,8 @@ describe('MetricExporter', () => {
     it('should export metrics', async () => {
       const meter = new MeterProvider().getMeter('test-meter');
       const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };
-      const counter = meter.createCounter('name', {
-        labelKeys: ['keya', 'keyb'],
-      });
-      counter.bind(labels).add(10);
+      const counter = meter.createCounter('name');
+      counter.add(10, labels);
       meter.collect();
       const records = meter.getBatcher().checkPointSet();
 
@@ -160,10 +158,8 @@ describe('MetricExporter', () => {
         metricDescriptors.getCall(0).args[0].resource.type,
         'custom.googleapis.com/opentelemetry/name'
       );
-
       assert.equal(metricDescriptors.callCount, 1);
       assert.equal(timeSeries.callCount, 1);
-
       assert.deepStrictEqual(result, ExportResult.SUCCESS);
     });
 
@@ -174,9 +170,7 @@ describe('MetricExporter', () => {
       let nMetrics = 401;
       while (nMetrics > 0) {
         nMetrics -= 1;
-        const counter = meter.createCounter(`name${nMetrics.toString()}`, {
-          labelKeys: ['keya', 'keyb'],
-        });
+        const counter = meter.createCounter(`name${nMetrics.toString()}`);
         counter.bind(labels).add(10);
       }
       meter.collect();

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
@@ -168,7 +168,6 @@ describe('MetricExporter', () => {
       assert.deepStrictEqual(result, ExportResult.SUCCESS);
     });
 
-
     it('should return retryable if there is an error sending TimeSeries', async () => {
       const meter = new MeterProvider().getMeter('test-meter');
       const labels: Labels = { ['keyb']: 'value2', ['keya']: 'value1' };

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -223,7 +223,7 @@ describe('transform', () => {
       const result = TEST_ONLY.transformPoint(
         point,
         metricDescriptor,
-        Date.now().toString()
+        new Date().toISOString()
       );
 
       assert.deepStrictEqual(result.value, { int64Value: 50 });
@@ -253,7 +253,7 @@ describe('transform', () => {
         TEST_ONLY.transformPoint(
           point,
           metricDescriptor,
-          Date.now().toString(),
+          new Date().toISOString(),
         );
         assert.fail('should have thrown an error');
       } catch (err) {
@@ -285,7 +285,7 @@ describe('transform', () => {
         TEST_ONLY.transformPoint(
           point,
           metricDescriptor,
-          Date.now().toString()
+          new Date().toISOString()
         );
         assert.fail('should have thrown an error');
       } catch (err) {

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -231,7 +231,7 @@ describe('transform', () => {
       assert(!result.interval.startTime);
     });
 
-    it('should throw an error when given a distriution value', () => {
+    it('should throw an error when given a distribution value', () => {
       const metricDescriptor: OTMetricDescriptor = {
         name: METRIC_NAME,
         description: METRIC_DESCRIPTION,

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -54,11 +54,11 @@ describe('transform', () => {
         MetricKind.CUMULATIVE
       );
       assert.strictEqual(
-        TEST_ONLY.transformMetricKind(OTMetricKind.SUM_OBSERVER),
+        TEST_ONLY.transformMetricKind(OTMetricKind.UP_DOWN_COUNTER),
         MetricKind.CUMULATIVE
       );
       assert.strictEqual(
-        TEST_ONLY.transformMetricKind(OTMetricKind.UP_DOWN_COUNTER),
+        TEST_ONLY.transformMetricKind(OTMetricKind.SUM_OBSERVER),
         MetricKind.GAUGE
       );
       assert.strictEqual(
@@ -178,10 +178,11 @@ describe('transform', () => {
       const labels: Labels = {keyb: 'value2', keya: 'value1'};
       const observer = meter.createObserver(METRIC_NAME, {
         description: METRIC_DESCRIPTION,
+        valueType: OTValueType.INT,
       });
-      const doubleValue = Math.random();
+      const int64Value = 0;
       observer.setCallback((result) => {
-        result.observe(() => doubleValue, labels);
+        result.observe(() => int64Value, labels);
       });
       meter.collect();
       const [record] = meter.getBatcher().checkPointSet();
@@ -200,9 +201,9 @@ describe('transform', () => {
         type: 'global',
       });
       assert.strictEqual(ts.metricKind, MetricKind.GAUGE);
-      assert.strictEqual(ts.valueType, ValueType.DOUBLE);
+      assert.strictEqual(ts.valueType, ValueType.INT64);
       assert.strictEqual(ts.points.length, 1);
-      assert.deepStrictEqual(ts.points[0].value, { doubleValue });
+      assert.deepStrictEqual(ts.points[0].value, { int64Value });
     });
   });
 });

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -176,13 +176,13 @@ describe('transform', () => {
 
     it('should return a Google Cloud Monitoring Metric for an observer', () => {
       const meter = new MeterProvider().getMeter('test-meter');
-      const labels: Labels = {keyb: 'value2', keya: 'value1'};
+      const labels: Labels = { keyb: 'value2', keya: 'value1' };
       const observer = meter.createObserver(METRIC_NAME, {
         description: METRIC_DESCRIPTION,
         valueType: OTValueType.INT,
       });
       const int64Value = 0;
-      observer.setCallback((result) => {
+      observer.setCallback(result => {
         result.observe(() => int64Value, labels);
       });
       meter.collect();
@@ -253,7 +253,7 @@ describe('transform', () => {
         TEST_ONLY.transformPoint(
           point,
           metricDescriptor,
-          new Date().toISOString(),
+          new Date().toISOString()
         );
         assert.fail('should have thrown an error');
       } catch (err) {

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -54,11 +54,11 @@ describe('transform', () => {
         MetricKind.CUMULATIVE
       );
       assert.strictEqual(
-        TEST_ONLY.transformMetricKind(OTMetricKind.UP_DOWN_COUNTER),
+        TEST_ONLY.transformMetricKind(OTMetricKind.SUM_OBSERVER),
         MetricKind.CUMULATIVE
       );
       assert.strictEqual(
-        TEST_ONLY.transformMetricKind(OTMetricKind.SUM_OBSERVER),
+        TEST_ONLY.transformMetricKind(OTMetricKind.UP_DOWN_COUNTER),
         MetricKind.GAUGE
       );
       assert.strictEqual(


### PR DESCRIPTION
This PR upgrades the cloud monitoring exporter's dependency on @opentelemetry/metrics to the latest release (0.9.0).

### Changes
The biggest change to @opentelemetry/metrics was the [removal](https://github.com/open-telemetry/opentelemetry-js/pull/1126) of `labelKeys` from `MetricOptions`. In response, labels are now added to GCP metrics using the metric instead of the metric descriptor as per the [GCP Docs](https://cloud.google.com/monitoring/custom-metrics/creating-metrics#md-modify)

Functions were adjusted to handle the additional `MetricKind`s that were [added](https://github.com/open-telemetry/opentelemetry-js/pull/1145)

### Testing 
Added some additional unit tests; all tests pass. 
Tested metric export on a GCE VM running the latest version of node.



Fixes #102 