### PR TITLE
feat: add support for Distributions

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -237,23 +237,15 @@ function transformValue(
   value: number | OTDistribution | OTHistogram
 ) {
   if (isDistributionValue(value)) {
-    // minimum two buckets due to mandatory buckets params in Cloud Monitoring API v3
-    return {
-      distributionValue: {
-        count: value.count,
-        mean: value.sum / value.count,
-        // sumOfSquaredDeviation param not aggregated
-        bucketOptions: { explicitBuckets: { bounds: [value.min] } },
-        bucketCounts: [0, value.count],
-      },
-    };
+    throw Error('unsupported distribution value type');
+    // no buckets aggregated, which is a required param in `histogramValue` for Cloud Monitoring v3
   }
   if (isHistogramValue(value)) {
     return {
       distributionValue: {
+        // sumOfSquaredDeviation param not aggregated
         count: value.count,
         mean: value.sum / value.count,
-        // sumOfSquaredDeviation param not aggregated
         bucketOptions: {
           explicitBuckets: { bounds: value.buckets.boundaries },
         },

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -237,12 +237,24 @@ function transformValue(
   value: number | OTDistribution | OTHistogram
 ) {
   if (isDistributionValue(value)) {
-    // TODO: Add support for Distribution
-    throw new Error('Distributions are not yet supported');
+    return { distributionValue: {
+        count: value.count,
+        mean: value.sum / value.count, // TODO: double or int?
+        sumOfSquaredDeviation: -1, // FIXME: not available
+        bucketOptions: { explicitBuckets: { bounds: [] } },
+        bucketCounts: [],
+        exemplars: null,
+    } };
   }
   if (isHistogramValue(value)) {
-    // TODO: Add support for Histogram
-    throw new Error('Histograms are not yet supported');
+    return { distributionValue: {
+      count: value.count,
+      mean: value.sum / value.count, // TODO: double or int?
+      sumOfSquaredDeviation: -1, // TODO: calculate
+      bucketOptions: { explicitBuckets: { bounds: value.buckets.boundaries } },
+      bucketCounts: value.buckets.counts,
+      exemplars: null,
+  } };
   }
 
   if (valueType === OTValueType.INT) {

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -238,7 +238,7 @@ function transformValue(
 ) {
   if (isDistributionValue(value)) {
     throw Error('unsupported distribution value type');
-    // no buckets aggregated, which is a required param in `histogramValue` for Cloud Monitoring v3
+    // no buckets aggregated, which is a required param in `distributionValue` for Cloud Monitoring v3
   }
   if (isHistogramValue(value)) {
     return {

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -238,14 +238,13 @@ function transformValue(
 ) {
   if (isDistributionValue(value)) {
     // minimum two buckets due to mandatory buckets params in Cloud Monitoring API v3
-    return { 
+    return {
       distributionValue: {
         count: value.count,
-        mean: value.sum / value.count, 
+        mean: value.sum / value.count,
         // sumOfSquaredDeviation param not aggregated
         bucketOptions: { explicitBuckets: { bounds: [value.min] } },
         bucketCounts: [0, value.count],
-        exemplars: null,
       },
     };
   }
@@ -255,9 +254,10 @@ function transformValue(
         count: value.count,
         mean: value.sum / value.count,
         // sumOfSquaredDeviation param not aggregated
-        bucketOptions: { explicitBuckets: { bounds: value.buckets.boundaries } },
+        bucketOptions: {
+          explicitBuckets: { bounds: value.buckets.boundaries }
+        },
         bucketCounts: value.buckets.counts,
-        exemplars: null,
       },
     };
   }

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -237,20 +237,21 @@ function transformValue(
   value: number | OTDistribution | OTHistogram
 ) {
   if (isDistributionValue(value)) {
+    // minimum two buckets due to mandatory buckets params in Cloud Monitoring API v3
     return { distributionValue: {
         count: value.count,
-        mean: value.sum / value.count, // TODO: double or int?
-        sumOfSquaredDeviation: -1, // FIXME: not available
-        bucketOptions: { explicitBuckets: { bounds: [] } },
-        bucketCounts: [],
+        mean: value.sum / value.count, 
+        // sumOfSquaredDeviation param not aggregated
+        bucketOptions: { explicitBuckets: { bounds: [value.min] } },
+        bucketCounts: [0, value.count],
         exemplars: null,
     } };
   }
   if (isHistogramValue(value)) {
     return { distributionValue: {
       count: value.count,
-      mean: value.sum / value.count, // TODO: double or int?
-      sumOfSquaredDeviation: -1, // TODO: calculate
+      mean: value.sum / value.count,
+      // sumOfSquaredDeviation param not aggregated
       bucketOptions: { explicitBuckets: { bounds: value.buckets.boundaries } },
       bucketCounts: value.buckets.counts,
       exemplars: null,

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -255,7 +255,7 @@ function transformValue(
         mean: value.sum / value.count,
         // sumOfSquaredDeviation param not aggregated
         bucketOptions: {
-          explicitBuckets: { bounds: value.buckets.boundaries }
+          explicitBuckets: { bounds: value.buckets.boundaries },
         },
         bucketCounts: value.buckets.counts,
       },

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -238,24 +238,28 @@ function transformValue(
 ) {
   if (isDistributionValue(value)) {
     // minimum two buckets due to mandatory buckets params in Cloud Monitoring API v3
-    return { distributionValue: {
+    return { 
+      distributionValue: {
         count: value.count,
         mean: value.sum / value.count, 
         // sumOfSquaredDeviation param not aggregated
         bucketOptions: { explicitBuckets: { bounds: [value.min] } },
         bucketCounts: [0, value.count],
         exemplars: null,
-    } };
+      },
+    };
   }
   if (isHistogramValue(value)) {
-    return { distributionValue: {
-      count: value.count,
-      mean: value.sum / value.count,
-      // sumOfSquaredDeviation param not aggregated
-      bucketOptions: { explicitBuckets: { bounds: value.buckets.boundaries } },
-      bucketCounts: value.buckets.counts,
-      exemplars: null,
-  } };
+    return {
+      distributionValue: {
+        count: value.count,
+        mean: value.sum / value.count,
+        // sumOfSquaredDeviation param not aggregated
+        bucketOptions: { explicitBuckets: { bounds: value.buckets.boundaries } },
+        bucketCounts: value.buckets.counts,
+        exemplars: null,
+      },
+    };
   }
 
   if (valueType === OTValueType.INT) {

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/types.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/types.ts
@@ -88,7 +88,7 @@ export interface Point {
 export interface Distribution {
   count: number;
   mean: number;
-  sumOfSquaredDeviation: number;
+  sumOfSquaredDeviation?: number;
   bucketOptions: { explicitBuckets: { bounds: Bucket[] } };
   bucketCounts: number[];
   exemplars?: Exemplar[];

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -365,7 +365,7 @@ describe('transform', () => {
           metricDescriptor,
           new Date().toISOString()
         )
-      }, "unsupported distribution value type");
+      }, /unsupported distribution value type/);
     });
 
     it('should export a histogram value', () => {

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -366,18 +366,21 @@ describe('transform', () => {
       );
 
       assert.deepStrictEqual(result.value, { distributionValue: {
-        bucketCounts: [],
-        bucketOptions: {
-          explicitBuckets: {
-            bounds: []
-          }
-        },
-        count: 22,
-        exemplars: null,
-        mean: 6.818181818181818,
-        sumOfSquaredDeviation: -1
-        }
-       });
+        bucketCounts: [
+            0,
+            22
+          ],
+          bucketOptions: {
+            explicitBuckets: {
+              bounds: [
+                20
+              ]
+            }
+          },
+          count: 22,
+          exemplars: null,
+          mean: 6.818181818181818
+       }});
       assert(result.interval.endTime);
       assert(result.interval.startTime);
     });
@@ -424,7 +427,6 @@ describe('transform', () => {
           count: 3,
           exemplars: null,
           mean: 23.333333333333332,
-        sumOfSquaredDeviation: -1
         }
        });
       assert(result.interval.endTime);

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -374,7 +374,6 @@ describe('transform', () => {
             },
           },
           count: 22,
-          exemplars: null,
           mean: 6.818181818181818,
         },
       });
@@ -417,7 +416,6 @@ describe('transform', () => {
             },
           },
           count: 3,
-          exemplars: null,
           mean: 23.333333333333332,
         },
       });

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -365,22 +365,24 @@ describe('transform', () => {
         new Date().toISOString()
       );
 
-      assert.deepStrictEqual(result.value, { distributionValue: {
-        bucketCounts: [
-            0,
-            22
-          ],
-          bucketOptions: {
-            explicitBuckets: {
-              bounds: [
-                20
-              ]
-            }
-          },
-          count: 22,
-          exemplars: null,
-          mean: 6.818181818181818
-       }});
+      assert.deepStrictEqual(result.value, {
+        distributionValue: {
+          bucketCounts: [
+              0,
+              22
+            ],
+            bucketOptions: {
+              explicitBuckets: {
+                bounds: [
+                  20
+                ]
+              }
+            },
+            count: 22,
+            exemplars: null,
+            mean: 6.818181818181818
+        },
+      });
       assert(result.interval.endTime);
       assert(result.interval.startTime);
     });
@@ -411,23 +413,24 @@ describe('transform', () => {
         new Date().toISOString()
       );
 
-      assert.deepStrictEqual(result.value, { distributionValue: {
-        bucketCounts: [
-            1,
-            2
-          ],
-          bucketOptions: {
-            explicitBuckets: {
-              bounds: [
-                10,
-                30
-              ]
-            }
-          },
-          count: 3,
-          exemplars: null,
-          mean: 23.333333333333332,
-        }
+      assert.deepStrictEqual(result.value, {
+        distributionValue: {
+          bucketCounts: [
+              1,
+              2
+            ],
+            bucketOptions: {
+              explicitBuckets: {
+                bounds: [
+                  10,
+                  30
+                ]
+              }
+            },
+            count: 3,
+            exemplars: null,
+            mean: 23.333333333333332,
+        },
        });
       assert(result.interval.endTime);
       assert(result.interval.startTime);

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -371,11 +371,11 @@ describe('transform', () => {
           bucketOptions: {
             explicitBuckets: {
               bounds: [20],
-            }
+            },
           },
           count: 22,
           exemplars: null,
-          mean: 6.818181818181818
+          mean: 6.818181818181818,
         },
       });
       assert(result.interval.endTime);
@@ -414,13 +414,13 @@ describe('transform', () => {
           bucketOptions: {
             explicitBuckets: {
               bounds: [10, 30],
-            }
+            },
           },
           count: 3,
           exemplars: null,
           mean: 23.333333333333332,
         },
-       });
+      });
       assert(result.interval.endTime);
       assert(result.interval.startTime);
     });

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -359,26 +359,13 @@ describe('transform', () => {
         timestamp: process.hrtime(),
       };
 
-      const result = TEST_ONLY.transformPoint(
-        point,
-        metricDescriptor,
-        new Date().toISOString()
-      );
-
-      assert.deepStrictEqual(result.value, {
-        distributionValue: {
-          bucketCounts: [0, 22],
-          bucketOptions: {
-            explicitBuckets: {
-              bounds: [20],
-            },
-          },
-          count: 22,
-          mean: 6.818181818181818,
-        },
-      });
-      assert(result.interval.endTime);
-      assert(result.interval.startTime);
+      assert.throws(() => {
+        return TEST_ONLY.transformPoint(
+          point,
+          metricDescriptor,
+          new Date().toISOString()
+        )
+      }, "unsupported distribution value type");
     });
 
     it('should export a histogram value', () => {

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -341,7 +341,7 @@ describe('transform', () => {
       assert(!result.interval.startTime);
     });
 
-    it('should throw an error when given a distribution value', () => {
+    it('should export a distribution value', () => {
       const metricDescriptor: OTMetricDescriptor = {
         name: METRIC_NAME,
         description: METRIC_DESCRIPTION,
@@ -359,19 +359,30 @@ describe('transform', () => {
         timestamp: process.hrtime(),
       };
 
-      try {
-        TEST_ONLY.transformPoint(
-          point,
-          metricDescriptor,
-          new Date().toISOString()
-        );
-        assert.fail('should have thrown an error');
-      } catch (err) {
-        assert(err.message.toLowerCase().includes('distributions'));
-      }
+      const result = TEST_ONLY.transformPoint(
+        point,
+        metricDescriptor,
+        new Date().toISOString()
+      );
+
+      assert.deepStrictEqual(result.value, { distributionValue: {
+        bucketCounts: [],
+        bucketOptions: {
+          explicitBuckets: {
+            bounds: []
+          }
+        },
+        count: 22,
+        exemplars: null,
+        mean: 6.818181818181818,
+        sumOfSquaredDeviation: -1
+        }
+       });
+      assert(result.interval.endTime);
+      assert(result.interval.startTime);
     });
 
-    it('should thrown an error when given a histogram value', () => {
+    it('should export a histogram value', () => {
       const metricDescriptor: OTMetricDescriptor = {
         name: METRIC_NAME,
         description: METRIC_DESCRIPTION,
@@ -391,16 +402,33 @@ describe('transform', () => {
         timestamp: process.hrtime(),
       };
 
-      try {
-        TEST_ONLY.transformPoint(
-          point,
-          metricDescriptor,
-          new Date().toISOString()
-        );
-        assert.fail('should have thrown an error');
-      } catch (err) {
-        assert(err.message.toLowerCase().includes('histograms'));
-      }
+      const result = TEST_ONLY.transformPoint(
+        point,
+        metricDescriptor,
+        new Date().toISOString()
+      );
+
+      assert.deepStrictEqual(result.value, { distributionValue: {
+        bucketCounts: [
+            1,
+            2
+          ],
+          bucketOptions: {
+            explicitBuckets: {
+              bounds: [
+                10,
+                30
+              ]
+            }
+          },
+          count: 3,
+          exemplars: null,
+          mean: 23.333333333333332,
+        sumOfSquaredDeviation: -1
+        }
+       });
+      assert(result.interval.endTime);
+      assert(result.interval.startTime);
     });
   });
 });

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -367,20 +367,15 @@ describe('transform', () => {
 
       assert.deepStrictEqual(result.value, {
         distributionValue: {
-          bucketCounts: [
-              0,
-              22
-            ],
-            bucketOptions: {
-              explicitBuckets: {
-                bounds: [
-                  20
-                ]
-              }
-            },
-            count: 22,
-            exemplars: null,
-            mean: 6.818181818181818
+          bucketCounts: [0, 22],
+          bucketOptions: {
+            explicitBuckets: {
+              bounds: [20],
+            }
+          },
+          count: 22,
+          exemplars: null,
+          mean: 6.818181818181818
         },
       });
       assert(result.interval.endTime);
@@ -415,21 +410,15 @@ describe('transform', () => {
 
       assert.deepStrictEqual(result.value, {
         distributionValue: {
-          bucketCounts: [
-              1,
-              2
-            ],
-            bucketOptions: {
-              explicitBuckets: {
-                bounds: [
-                  10,
-                  30
-                ]
-              }
-            },
-            count: 3,
-            exemplars: null,
-            mean: 23.333333333333332,
+          bucketCounts: [1, 2],
+          bucketOptions: {
+            explicitBuckets: {
+              bounds: [10, 30],
+            }
+          },
+          count: 3,
+          exemplars: null,
+          mean: 23.333333333333332,
         },
        });
       assert(result.interval.endTime);

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -364,7 +364,7 @@ describe('transform', () => {
           point,
           metricDescriptor,
           new Date().toISOString()
-        )
+        );
       }, /unsupported distribution value type/);
     });
 


### PR DESCRIPTION
Addresses: https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/101

### Summary
Adding support for exporting OpenTelemetry Distribution and Histogram types as Cloud Monitoring API v3 Distributions

### Tests
* Tested manually with exporting to personal GCP project
* Updated unit tests
