### PR TITLE
feat: upgrade packages to opentelemetry version 0.11.0

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/package-lock.json
+++ b/packages/opentelemetry-cloud-monitoring-exporter/package-lock.json
@@ -300,115 +300,50 @@
       "dev": true
     },
     "@opentelemetry/api": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.8.3.tgz",
-      "integrity": "sha512-CRd8kKrMN1yisbw2zc2IiXM31zdS8mvQ4sivxPFgWS/eQEW9XuNxMVtSWv5k/tDcqbcLzUHcX6JW0SpVNA5h+g==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.11.0.tgz",
+      "integrity": "sha512-K+1ADLMxduhsXoZ0GRfi9Pw162FvzBQLDQlHru1lg86rpIU+4XqdJkSGo6y3Kg+GmOWq1HNHOA/ydw/rzHQkRg==",
       "dev": true,
       "requires": {
-        "@opentelemetry/context-base": "^0.8.3"
-      },
-      "dependencies": {
-        "@opentelemetry/context-base": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.8.3.tgz",
-          "integrity": "sha512-rnW85ubtTn2tA0Gg7MXLP2yEi4EplEXXDe7JKx8SwCyzXrk8htTwg0AVlRtsH0T5XyDCfvKq8Nh4eKqbwBA9iA==",
-          "dev": true
-        }
+        "@opentelemetry/context-base": "^0.11.0"
       }
     },
     "@opentelemetry/context-base": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.8.3.tgz",
-      "integrity": "sha512-rnW85ubtTn2tA0Gg7MXLP2yEi4EplEXXDe7JKx8SwCyzXrk8htTwg0AVlRtsH0T5XyDCfvKq8Nh4eKqbwBA9iA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.11.0.tgz",
+      "integrity": "sha512-ESRk+572bftles7CVlugAj5Azrz61VO0MO0TS2pE9MLVL/zGmWuUBQryART6/nsrFqo+v9HPt37GPNcECTZR1w==",
       "dev": true
     },
     "@opentelemetry/core": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.8.0.tgz",
-      "integrity": "sha512-YKB+/OrLRsHYPzEMIK7QI+mBuyIjqeNLec3KcsAQQ3BEkd6aZzkjF2L/OG+nu2OV3yHDcs1/HOPz91zwYA4TVw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.11.0.tgz",
+      "integrity": "sha512-ZEKjBXeDGBqzouz0uJmrbEKNExEsQOhsZ3tJDCLcz5dUNoVw642oIn2LYWdQK2YdIfZbEmltiF65/csGsaBtFA==",
       "dev": true,
       "requires": {
-        "@opentelemetry/api": "^0.8.0",
-        "@opentelemetry/context-base": "^0.8.0",
+        "@opentelemetry/api": "^0.11.0",
+        "@opentelemetry/context-base": "^0.11.0",
         "semver": "^7.1.3"
       }
     },
     "@opentelemetry/metrics": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/metrics/-/metrics-0.9.0.tgz",
-      "integrity": "sha512-Gz7a8DCZ/UyDspdb2W/a1yQD0hT7uzjqjKpMgX0dTze/B9PUDdmKGjy1TOOUloQ4zw1YTtcwxL1CX3pVC/dzNA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/metrics/-/metrics-0.11.0.tgz",
+      "integrity": "sha512-OlEG1yVrfxkeQinx0c9/J37RPPnFKh0wRov0t2FHf2n2OnS831xhT9jSsopYlrJ5fe3NY0HuHshDoMpBOJXaGg==",
       "dev": true,
       "requires": {
-        "@opentelemetry/api": "^0.9.0",
-        "@opentelemetry/core": "^0.9.0",
-        "@opentelemetry/resources": "^0.9.0"
-      },
-      "dependencies": {
-        "@opentelemetry/api": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.9.0.tgz",
-          "integrity": "sha512-fJ0CzUf4favXihuD6dDUh4U6GPfEjswUy9w+N4SrIrX3wFi43bGb3BXPSctaWx3PQaRC3Rjsw12HWR+oRl9pRQ==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/context-base": "^0.9.0"
-          }
-        },
-        "@opentelemetry/context-base": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.9.0.tgz",
-          "integrity": "sha512-4XUS2RoGKla+lqbEBKN4NUmPtJI/+NHVt7EHaw6XxFlBwyZ9HAX61Kk53Hlb6eUYOLOehdVx9Q+gdpamj018iQ==",
-          "dev": true
-        },
-        "@opentelemetry/core": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.9.0.tgz",
-          "integrity": "sha512-OU4qmYbDTilvdNgr9rXIGgBh1GENPbQrkyAzob5l/4/blqTDi75a5S/ZfkNjweyVvufVbp81rpvSxu9oN9tg2g==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/api": "^0.9.0",
-            "@opentelemetry/context-base": "^0.9.0",
-            "semver": "^7.1.3"
-          }
-        }
+        "@opentelemetry/api": "^0.11.0",
+        "@opentelemetry/core": "^0.11.0",
+        "@opentelemetry/resources": "^0.11.0"
       }
     },
     "@opentelemetry/resources": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.9.0.tgz",
-      "integrity": "sha512-+eIEBfWm1/qGBOK8fL6wdi+2HIyssL9fRSAyTmWVp0VrM9tnIplJj9Jzttf6NArwvF4P+UayLh0s4BgYNSmnig==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.11.0.tgz",
+      "integrity": "sha512-o7DwV1TcezqBtS5YW2AWBcn01nVpPptIbTr966PLlVBcS//w8LkjeOShiSZxQ0lmV4b2en0FiSouSDoXk/5qIQ==",
       "dev": true,
       "requires": {
-        "@opentelemetry/api": "^0.9.0",
-        "@opentelemetry/core": "^0.9.0",
-        "gcp-metadata": "^3.5.0"
-      },
-      "dependencies": {
-        "@opentelemetry/api": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.9.0.tgz",
-          "integrity": "sha512-fJ0CzUf4favXihuD6dDUh4U6GPfEjswUy9w+N4SrIrX3wFi43bGb3BXPSctaWx3PQaRC3Rjsw12HWR+oRl9pRQ==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/context-base": "^0.9.0"
-          }
-        },
-        "@opentelemetry/context-base": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.9.0.tgz",
-          "integrity": "sha512-4XUS2RoGKla+lqbEBKN4NUmPtJI/+NHVt7EHaw6XxFlBwyZ9HAX61Kk53Hlb6eUYOLOehdVx9Q+gdpamj018iQ==",
-          "dev": true
-        },
-        "@opentelemetry/core": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.9.0.tgz",
-          "integrity": "sha512-OU4qmYbDTilvdNgr9rXIGgBh1GENPbQrkyAzob5l/4/blqTDi75a5S/ZfkNjweyVvufVbp81rpvSxu9oN9tg2g==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/api": "^0.9.0",
-            "@opentelemetry/context-base": "^0.9.0",
-            "semver": "^7.1.3"
-          }
-        }
+        "@opentelemetry/api": "^0.11.0",
+        "@opentelemetry/core": "^0.11.0"
       }
     },
     "@sindresorhus/is": {

--- a/packages/opentelemetry-cloud-monitoring-exporter/package.json
+++ b/packages/opentelemetry-cloud-monitoring-exporter/package.json
@@ -37,10 +37,10 @@
     "registry": "https://wombat-dressing-room.appspot.com"
   },
   "devDependencies": {
-    "@opentelemetry/api": "0.8.3",
-    "@opentelemetry/core": "0.8.0",
-    "@opentelemetry/metrics": "0.9.0",
-    "@opentelemetry/resources": "0.9.0",
+    "@opentelemetry/api": "^0.11.0",
+    "@opentelemetry/core": "^0.11.0",
+    "@opentelemetry/metrics": "^0.11.0",
+    "@opentelemetry/resources": "^0.11.0",
     "@types/mocha": "7.0.2",
     "@types/nock": "11.1.0",
     "@types/node": "12.12.51",
@@ -60,9 +60,9 @@
     "googleapis": "^46.0.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "0.8.3 - 0.10.x",
-    "@opentelemetry/core": "0.8.0 - 0.10.x",
-    "@opentelemetry/metrics": "0.9.0 - 0.10.x",
-    "@opentelemetry/resources": "0.9.0 - 0.10.x"
+    "@opentelemetry/api": "^0.11.0",
+    "@opentelemetry/core": "^0.11.0",
+    "@opentelemetry/metrics": "^0.11.0",
+    "@opentelemetry/resources": "^0.11.0"
   }
 }

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
@@ -150,7 +150,7 @@ describe('MetricExporter', () => {
       const labels: Labels = { ['keya']: 'value1', ['keyb']: 'value2' };
       const counter = meter.createCounter('name');
       counter.add(10, labels);
-      meter.collect();
+      await meter.collect();
       const records = meter.getBatcher().checkPointSet();
 
       const result = await new Promise((resolve, reject) => {
@@ -174,7 +174,7 @@ describe('MetricExporter', () => {
       const labels: Labels = { ['keya']: 'value1', ['keyb']: 'value2' };
       const counter = meter.createCounter('name');
       counter.add(10, labels);
-      meter.collect();
+      await meter.collect();
       const records = meter.getBatcher().checkPointSet();
       createTimeSeriesShouldFail = true;
       const result = await new Promise((resolve, reject) => {
@@ -201,7 +201,7 @@ describe('MetricExporter', () => {
         const counter = meter.createCounter(`name${nMetrics.toString()}`);
         counter.bind(labels).add(10);
       }
-      meter.collect();
+      await meter.collect();
       const records = meter.getBatcher().checkPointSet();
 
       const result = await new Promise((resolve, reject) => {

--- a/packages/opentelemetry-cloud-trace-exporter/package-lock.json
+++ b/packages/opentelemetry-cloud-trace-exporter/package-lock.json
@@ -325,75 +325,58 @@
       "dev": true
     },
     "@opentelemetry/api": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.8.0.tgz",
-      "integrity": "sha512-P7+9cdg55aBQxUPj/hst9uu3aPmbIxlqB9//pwa3XPDXtFsKEDH517Rq/TEZQob3255KDyE2JoTIpWDb2isYhg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.11.0.tgz",
+      "integrity": "sha512-K+1ADLMxduhsXoZ0GRfi9Pw162FvzBQLDQlHru1lg86rpIU+4XqdJkSGo6y3Kg+GmOWq1HNHOA/ydw/rzHQkRg==",
       "dev": true,
       "requires": {
-        "@opentelemetry/context-base": "^0.8.0"
+        "@opentelemetry/context-base": "^0.11.0"
       }
     },
     "@opentelemetry/context-base": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.8.3.tgz",
-      "integrity": "sha512-rnW85ubtTn2tA0Gg7MXLP2yEi4EplEXXDe7JKx8SwCyzXrk8htTwg0AVlRtsH0T5XyDCfvKq8Nh4eKqbwBA9iA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.11.0.tgz",
+      "integrity": "sha512-ESRk+572bftles7CVlugAj5Azrz61VO0MO0TS2pE9MLVL/zGmWuUBQryART6/nsrFqo+v9HPt37GPNcECTZR1w==",
       "dev": true
     },
     "@opentelemetry/core": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.8.3.tgz",
-      "integrity": "sha512-3MSnQlFWj6ikZU5QLtiZseL25HzCi0XpTvMMKMW8x/PlOsqBBD/52eN7JC4587R008ZUbx+7afB0yewBTseY0w==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.11.0.tgz",
+      "integrity": "sha512-ZEKjBXeDGBqzouz0uJmrbEKNExEsQOhsZ3tJDCLcz5dUNoVw642oIn2LYWdQK2YdIfZbEmltiF65/csGsaBtFA==",
       "dev": true,
       "requires": {
-        "@opentelemetry/api": "^0.8.3",
-        "@opentelemetry/context-base": "^0.8.3",
+        "@opentelemetry/api": "^0.11.0",
+        "@opentelemetry/context-base": "^0.11.0",
         "semver": "^7.1.3"
-      },
-      "dependencies": {
-        "@opentelemetry/api": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.8.3.tgz",
-          "integrity": "sha512-CRd8kKrMN1yisbw2zc2IiXM31zdS8mvQ4sivxPFgWS/eQEW9XuNxMVtSWv5k/tDcqbcLzUHcX6JW0SpVNA5h+g==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/context-base": "^0.8.3"
-          }
-        }
       }
     },
     "@opentelemetry/resources": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.8.0.tgz",
-      "integrity": "sha512-4mJFsZR7nAwl9UFLiy7Jy/GGfKsqGa49q0GL4r1F3eUzbClJBxZfgQAu9xIh7kiIy0R2xhAaJEyifOrYaQ2Jww==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.11.0.tgz",
+      "integrity": "sha512-o7DwV1TcezqBtS5YW2AWBcn01nVpPptIbTr966PLlVBcS//w8LkjeOShiSZxQ0lmV4b2en0FiSouSDoXk/5qIQ==",
       "dev": true,
       "requires": {
-        "@opentelemetry/api": "^0.8.0",
-        "@opentelemetry/core": "^0.8.0",
-        "gcp-metadata": "^3.5.0"
-      },
-      "dependencies": {
-        "gcp-metadata": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.5.0.tgz",
-          "integrity": "sha512-ZQf+DLZ5aKcRpLzYUyBS3yo3N0JSa82lNDO8rj3nMSlovLcz2riKFBsYgDzeXcv75oo5eqB2lx+B14UvPoCRnA==",
-          "dev": true,
-          "requires": {
-            "gaxios": "^2.1.0",
-            "json-bigint": "^0.3.0"
-          }
-        }
+        "@opentelemetry/api": "^0.11.0",
+        "@opentelemetry/core": "^0.11.0"
       }
     },
+    "@opentelemetry/semantic-conventions": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.11.0.tgz",
+      "integrity": "sha512-xsthnI/J+Cx0YVDGgUzvrH0ZTtfNtl866M454NarYwDrc0JvC24sYw+XS5PJyk2KDzAHtb0vlrumUc1OAut/Fw==",
+      "dev": true
+    },
     "@opentelemetry/tracing": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.8.0.tgz",
-      "integrity": "sha512-2xsGzw3St4JrxU7Bs8oSiB68nfdFkEksjCxtotJ7TsSHYDgOjzT16UADK+6kzzvgRa8C/VJYc/DIy8p2mx9YaQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.11.0.tgz",
+      "integrity": "sha512-QweFmxzl32BcyzwdWCNjVXZT1WeENNS/RWETq/ohqu+fAsTcMyGcr6cOq/yDdFmtBy+bm5WVVdeByEjNS+c4/w==",
       "dev": true,
       "requires": {
-        "@opentelemetry/api": "^0.8.0",
-        "@opentelemetry/context-base": "^0.8.0",
-        "@opentelemetry/core": "^0.8.0",
-        "@opentelemetry/resources": "^0.8.0"
+        "@opentelemetry/api": "^0.11.0",
+        "@opentelemetry/context-base": "^0.11.0",
+        "@opentelemetry/core": "^0.11.0",
+        "@opentelemetry/resources": "^0.11.0",
+        "@opentelemetry/semantic-conventions": "^0.11.0"
       }
     },
     "@protobufjs/aspromise": {

--- a/packages/opentelemetry-cloud-trace-exporter/package.json
+++ b/packages/opentelemetry-cloud-trace-exporter/package.json
@@ -37,9 +37,9 @@
     "registry": "https://wombat-dressing-room.appspot.com"
   },
   "devDependencies": {
-    "@opentelemetry/api": "0.8.0",
-    "@opentelemetry/resources": "0.8.0",
-    "@opentelemetry/tracing": "0.8.0",
+    "@opentelemetry/api": "^0.11.0",
+    "@opentelemetry/resources": "^0.11.0",
+    "@opentelemetry/tracing": "^0.11.0",
     "@types/mocha": "7.0.2",
     "@types/node": "12.12.51",
     "@types/sinon": "9.0.4",
@@ -61,9 +61,9 @@
     "grpc": "^1.24.3"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "0.8.0 - 0.10.x",
-    "@opentelemetry/core": "0.8.0 - 0.10.x",
-    "@opentelemetry/resources": "0.8.0 - 0.10.x",
-    "@opentelemetry/tracing": "0.8.0 - 0.10.x"
+    "@opentelemetry/api": "^0.11.0",
+    "@opentelemetry/core": "^0.11.0",
+    "@opentelemetry/resources": "^0.11.0",
+    "@opentelemetry/tracing": "^0.11.0"
   }
 }

--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -100,7 +100,7 @@ function transformAttributes(
     {},
     requestAttributes,
     serviceAttributes,
-    resource.labels
+    resource.attributes
   );
 
   const attributeMap = transformAttributeValues(attributes);

--- a/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
@@ -213,6 +213,7 @@ describe('Google Cloud Trace Exporter', () => {
         },
         status: { code: types.CanonicalCode.OK },
         resource: Resource.empty(),
+        instrumentationLibrary: { name: 'default', version: '0.0.1' },
       };
 
       const result = await new Promise((resolve, reject) => {
@@ -262,6 +263,7 @@ describe('Google Cloud Trace Exporter', () => {
         },
         status: { code: types.CanonicalCode.OK },
         resource: Resource.empty(),
+        instrumentationLibrary: { name: 'default', version: '0.0.1' },
       };
 
       await new Promise((resolve, reject) => {
@@ -301,6 +303,7 @@ describe('Google Cloud Trace Exporter', () => {
         },
         status: { code: types.CanonicalCode.OK },
         resource: Resource.empty(),
+        instrumentationLibrary: { name: 'default', version: '0.0.1' },
       };
 
       getClientShouldFail = true;
@@ -334,6 +337,7 @@ describe('Google Cloud Trace Exporter', () => {
         },
         status: { code: types.CanonicalCode.OK },
         resource: Resource.empty(),
+        instrumentationLibrary: { name: 'default', version: '0.0.1' },
       };
 
       batchWriteShouldFail = true;
@@ -365,6 +369,7 @@ describe('Google Cloud Trace Exporter', () => {
         },
         status: { code: types.CanonicalCode.OK },
         resource: Resource.empty(),
+        instrumentationLibrary: { name: 'default', version: '0.0.1' },
       };
 
       await exporter['_projectId'];

--- a/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
@@ -53,6 +53,7 @@ describe('transform', () => {
         version: 1,
         cost: 112.12,
       }),
+      instrumentationLibrary: { name: 'default', version: '0.0.1' },
     };
   });
 

--- a/packages/opentelemetry-cloud-trace-propagator/package-lock.json
+++ b/packages/opentelemetry-cloud-trace-propagator/package-lock.json
@@ -291,28 +291,28 @@
       "dev": true
     },
     "@opentelemetry/api": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.10.2.tgz",
-      "integrity": "sha512-GtpMGd6vkzDMYcpu2t9LlhEgMy/SzBwRnz48EejlRArYqZzqSzAsKmegUK7zHgl+EOIaK9mKHhnRaQu3qw20cA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.11.0.tgz",
+      "integrity": "sha512-K+1ADLMxduhsXoZ0GRfi9Pw162FvzBQLDQlHru1lg86rpIU+4XqdJkSGo6y3Kg+GmOWq1HNHOA/ydw/rzHQkRg==",
       "dev": true,
       "requires": {
-        "@opentelemetry/context-base": "^0.10.2"
+        "@opentelemetry/context-base": "^0.11.0"
       }
     },
     "@opentelemetry/context-base": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.10.2.tgz",
-      "integrity": "sha512-hZNKjKOYsckoOEgBziGMnBcX0M7EtstnCmwz5jZUOUYwlZ+/xxX6z3jPu1XVO2Jivk0eLfuP9GP+vFD49CMetw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.11.0.tgz",
+      "integrity": "sha512-ESRk+572bftles7CVlugAj5Azrz61VO0MO0TS2pE9MLVL/zGmWuUBQryART6/nsrFqo+v9HPt37GPNcECTZR1w==",
       "dev": true
     },
     "@opentelemetry/core": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.10.2.tgz",
-      "integrity": "sha512-DhkiTp5eje2zTGd+HAIKWpGE6IR6lq7tUpYt4nnkhOi6Hq9WQAANVDCWEZEbYOw57LkdXbE50FZ/kMvHDm450Q==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.11.0.tgz",
+      "integrity": "sha512-ZEKjBXeDGBqzouz0uJmrbEKNExEsQOhsZ3tJDCLcz5dUNoVw642oIn2LYWdQK2YdIfZbEmltiF65/csGsaBtFA==",
       "dev": true,
       "requires": {
-        "@opentelemetry/api": "^0.10.2",
-        "@opentelemetry/context-base": "^0.10.2",
+        "@opentelemetry/api": "^0.11.0",
+        "@opentelemetry/context-base": "^0.11.0",
         "semver": "^7.1.3"
       },
       "dependencies": {

--- a/packages/opentelemetry-cloud-trace-propagator/package.json
+++ b/packages/opentelemetry-cloud-trace-propagator/package.json
@@ -37,8 +37,8 @@
     "registry": "https://wombat-dressing-room.appspot.com"
   },
   "devDependencies": {
-    "@opentelemetry/api": "0.10.2",
-    "@opentelemetry/core": "0.10.2",
+    "@opentelemetry/api": "^0.11.0",
+    "@opentelemetry/core": "^0.11.0",
     "@types/mocha": "7.0.2",
     "@types/node": "14.0.14",
     "codecov": "3.7.1",
@@ -53,7 +53,7 @@
     "hex2dec": "^1.0.1"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^0.10.0",
-    "@opentelemetry/core": "^0.10.0"
+    "@opentelemetry/api": "^0.11.0",
+    "@opentelemetry/core": "^0.11.0"
   }
 }

--- a/packages/opentelemetry-cloud-trace-propagator/src/CloudPropagator.ts
+++ b/packages/opentelemetry-cloud-trace-propagator/src/CloudPropagator.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {
-  HttpTextPropagator,
+  TextMapPropagator,
   Context,
   SetterFunction,
   GetterFunction,
@@ -44,7 +44,7 @@ import {
 /** Header that carries span context across Google infrastructure. */
 export const X_CLOUD_TRACE_HEADER = 'x-cloud-trace-context';
 
-export class CloudPropagator implements HttpTextPropagator {
+export class CloudPropagator implements TextMapPropagator {
   inject(context: Context, carrier: unknown, setter: SetterFunction): void {
     const spanContext = getParentSpanContext(context);
     if (!spanContext) return;

--- a/samples/trace/package-lock.json
+++ b/samples/trace/package-lock.json
@@ -302,68 +302,52 @@
           "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw=="
         },
         "@opentelemetry/api": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.8.0.tgz",
-          "integrity": "sha512-P7+9cdg55aBQxUPj/hst9uu3aPmbIxlqB9//pwa3XPDXtFsKEDH517Rq/TEZQob3255KDyE2JoTIpWDb2isYhg==",
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.11.0.tgz",
+          "integrity": "sha512-K+1ADLMxduhsXoZ0GRfi9Pw162FvzBQLDQlHru1lg86rpIU+4XqdJkSGo6y3Kg+GmOWq1HNHOA/ydw/rzHQkRg==",
           "requires": {
-            "@opentelemetry/context-base": "^0.8.0"
+            "@opentelemetry/context-base": "^0.11.0"
           }
         },
         "@opentelemetry/context-base": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.8.3.tgz",
-          "integrity": "sha512-rnW85ubtTn2tA0Gg7MXLP2yEi4EplEXXDe7JKx8SwCyzXrk8htTwg0AVlRtsH0T5XyDCfvKq8Nh4eKqbwBA9iA=="
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.11.0.tgz",
+          "integrity": "sha512-ESRk+572bftles7CVlugAj5Azrz61VO0MO0TS2pE9MLVL/zGmWuUBQryART6/nsrFqo+v9HPt37GPNcECTZR1w=="
         },
         "@opentelemetry/core": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.8.3.tgz",
-          "integrity": "sha512-3MSnQlFWj6ikZU5QLtiZseL25HzCi0XpTvMMKMW8x/PlOsqBBD/52eN7JC4587R008ZUbx+7afB0yewBTseY0w==",
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.11.0.tgz",
+          "integrity": "sha512-ZEKjBXeDGBqzouz0uJmrbEKNExEsQOhsZ3tJDCLcz5dUNoVw642oIn2LYWdQK2YdIfZbEmltiF65/csGsaBtFA==",
           "requires": {
-            "@opentelemetry/api": "^0.8.3",
-            "@opentelemetry/context-base": "^0.8.3",
+            "@opentelemetry/api": "^0.11.0",
+            "@opentelemetry/context-base": "^0.11.0",
             "semver": "^7.1.3"
-          },
-          "dependencies": {
-            "@opentelemetry/api": {
-              "version": "0.8.3",
-              "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.8.3.tgz",
-              "integrity": "sha512-CRd8kKrMN1yisbw2zc2IiXM31zdS8mvQ4sivxPFgWS/eQEW9XuNxMVtSWv5k/tDcqbcLzUHcX6JW0SpVNA5h+g==",
-              "requires": {
-                "@opentelemetry/context-base": "^0.8.3"
-              }
-            }
           }
         },
         "@opentelemetry/resources": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.8.0.tgz",
-          "integrity": "sha512-4mJFsZR7nAwl9UFLiy7Jy/GGfKsqGa49q0GL4r1F3eUzbClJBxZfgQAu9xIh7kiIy0R2xhAaJEyifOrYaQ2Jww==",
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.11.0.tgz",
+          "integrity": "sha512-o7DwV1TcezqBtS5YW2AWBcn01nVpPptIbTr966PLlVBcS//w8LkjeOShiSZxQ0lmV4b2en0FiSouSDoXk/5qIQ==",
           "requires": {
-            "@opentelemetry/api": "^0.8.0",
-            "@opentelemetry/core": "^0.8.0",
-            "gcp-metadata": "^3.5.0"
-          },
-          "dependencies": {
-            "gcp-metadata": {
-              "version": "3.5.0",
-              "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.5.0.tgz",
-              "integrity": "sha512-ZQf+DLZ5aKcRpLzYUyBS3yo3N0JSa82lNDO8rj3nMSlovLcz2riKFBsYgDzeXcv75oo5eqB2lx+B14UvPoCRnA==",
-              "requires": {
-                "gaxios": "^2.1.0",
-                "json-bigint": "^0.3.0"
-              }
-            }
+            "@opentelemetry/api": "^0.11.0",
+            "@opentelemetry/core": "^0.11.0"
           }
         },
+        "@opentelemetry/semantic-conventions": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.11.0.tgz",
+          "integrity": "sha512-xsthnI/J+Cx0YVDGgUzvrH0ZTtfNtl866M454NarYwDrc0JvC24sYw+XS5PJyk2KDzAHtb0vlrumUc1OAut/Fw=="
+        },
         "@opentelemetry/tracing": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.8.0.tgz",
-          "integrity": "sha512-2xsGzw3St4JrxU7Bs8oSiB68nfdFkEksjCxtotJ7TsSHYDgOjzT16UADK+6kzzvgRa8C/VJYc/DIy8p2mx9YaQ==",
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.11.0.tgz",
+          "integrity": "sha512-QweFmxzl32BcyzwdWCNjVXZT1WeENNS/RWETq/ohqu+fAsTcMyGcr6cOq/yDdFmtBy+bm5WVVdeByEjNS+c4/w==",
           "requires": {
-            "@opentelemetry/api": "^0.8.0",
-            "@opentelemetry/context-base": "^0.8.0",
-            "@opentelemetry/core": "^0.8.0",
-            "@opentelemetry/resources": "^0.8.0"
+            "@opentelemetry/api": "^0.11.0",
+            "@opentelemetry/context-base": "^0.11.0",
+            "@opentelemetry/core": "^0.11.0",
+            "@opentelemetry/resources": "^0.11.0",
+            "@opentelemetry/semantic-conventions": "^0.11.0"
           }
         },
         "@protobufjs/aspromise": {
@@ -4823,164 +4807,81 @@
       }
     },
     "@opentelemetry/api": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.10.2.tgz",
-      "integrity": "sha512-GtpMGd6vkzDMYcpu2t9LlhEgMy/SzBwRnz48EejlRArYqZzqSzAsKmegUK7zHgl+EOIaK9mKHhnRaQu3qw20cA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.11.0.tgz",
+      "integrity": "sha512-K+1ADLMxduhsXoZ0GRfi9Pw162FvzBQLDQlHru1lg86rpIU+4XqdJkSGo6y3Kg+GmOWq1HNHOA/ydw/rzHQkRg==",
       "requires": {
-        "@opentelemetry/context-base": "^0.10.2"
+        "@opentelemetry/context-base": "^0.11.0"
       }
     },
     "@opentelemetry/context-async-hooks": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.10.2.tgz",
-      "integrity": "sha512-0Z8Slx4zCN4aKuJlLkS6GkgmBUkgwz0Ltvrd2+QvDbKTtFGROdiywDfn4fbDEYqm638Dtev19am4AQZ3PHljqQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.11.0.tgz",
+      "integrity": "sha512-4z0X9EfvoLNA6R5yi+2taUyaSCUiyi/ht1qBYZMgpWvWwARgc5hcgGkZo7bekPk1zWfE9NFIhW6ySOXOP9CXyQ==",
       "requires": {
-        "@opentelemetry/context-base": "^0.10.2"
+        "@opentelemetry/context-base": "^0.11.0"
       }
     },
     "@opentelemetry/context-base": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.10.2.tgz",
-      "integrity": "sha512-hZNKjKOYsckoOEgBziGMnBcX0M7EtstnCmwz5jZUOUYwlZ+/xxX6z3jPu1XVO2Jivk0eLfuP9GP+vFD49CMetw=="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.11.0.tgz",
+      "integrity": "sha512-ESRk+572bftles7CVlugAj5Azrz61VO0MO0TS2pE9MLVL/zGmWuUBQryART6/nsrFqo+v9HPt37GPNcECTZR1w=="
     },
     "@opentelemetry/core": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.10.2.tgz",
-      "integrity": "sha512-DhkiTp5eje2zTGd+HAIKWpGE6IR6lq7tUpYt4nnkhOi6Hq9WQAANVDCWEZEbYOw57LkdXbE50FZ/kMvHDm450Q==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.11.0.tgz",
+      "integrity": "sha512-ZEKjBXeDGBqzouz0uJmrbEKNExEsQOhsZ3tJDCLcz5dUNoVw642oIn2LYWdQK2YdIfZbEmltiF65/csGsaBtFA==",
       "requires": {
-        "@opentelemetry/api": "^0.10.2",
-        "@opentelemetry/context-base": "^0.10.2",
+        "@opentelemetry/api": "^0.11.0",
+        "@opentelemetry/context-base": "^0.11.0",
         "semver": "^7.1.3"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-        }
       }
     },
     "@opentelemetry/node": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/node/-/node-0.10.2.tgz",
-      "integrity": "sha512-OnX5i4/PPMoQjfEYVmfdiS/APrT+E4YSOcI0HUhRLjYvs6Z80DUBg3phzIsRPqF1mLqiHHn/8aSqrlxRTofWhg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/node/-/node-0.11.0.tgz",
+      "integrity": "sha512-1SrZNbF7aBShySvsmWL+3bir6fVugjSnCyXsKMwclinhZIHd2cUfgjKdi42OCcA5G4Pp8TpO7/8ue8qI5yKX8w==",
       "requires": {
-        "@opentelemetry/api": "^0.10.2",
-        "@opentelemetry/context-async-hooks": "^0.10.2",
-        "@opentelemetry/core": "^0.10.2",
-        "@opentelemetry/tracing": "^0.10.2",
+        "@opentelemetry/api": "^0.11.0",
+        "@opentelemetry/context-async-hooks": "^0.11.0",
+        "@opentelemetry/core": "^0.11.0",
+        "@opentelemetry/tracing": "^0.11.0",
         "require-in-the-middle": "^5.0.0",
         "semver": "^7.1.3"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-        }
       }
     },
     "@opentelemetry/resources": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.10.2.tgz",
-      "integrity": "sha512-5JGC2TPSAIHth615IURt+sSsTljY43zTfJD0JE9PHC6ipZPiQ0dpQDZOrLn8NAMfOHY1jeWwpIuLASjqbXUfuw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.11.0.tgz",
+      "integrity": "sha512-o7DwV1TcezqBtS5YW2AWBcn01nVpPptIbTr966PLlVBcS//w8LkjeOShiSZxQ0lmV4b2en0FiSouSDoXk/5qIQ==",
       "requires": {
-        "@opentelemetry/api": "^0.10.2",
-        "@opentelemetry/core": "^0.10.2",
-        "gcp-metadata": "^3.5.0"
+        "@opentelemetry/api": "^0.11.0",
+        "@opentelemetry/core": "^0.11.0"
       }
+    },
+    "@opentelemetry/semantic-conventions": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.11.0.tgz",
+      "integrity": "sha512-xsthnI/J+Cx0YVDGgUzvrH0ZTtfNtl866M454NarYwDrc0JvC24sYw+XS5PJyk2KDzAHtb0vlrumUc1OAut/Fw=="
     },
     "@opentelemetry/tracing": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.10.2.tgz",
-      "integrity": "sha512-mNAhARn4dEdOjTa9OdysjI4fRHMbvr4YSbPuH7jhkyPzgoa+DnvnbY3GGpEay6kpuYJsrW8Ef9OIKAV/GndhbQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.11.0.tgz",
+      "integrity": "sha512-QweFmxzl32BcyzwdWCNjVXZT1WeENNS/RWETq/ohqu+fAsTcMyGcr6cOq/yDdFmtBy+bm5WVVdeByEjNS+c4/w==",
       "requires": {
-        "@opentelemetry/api": "^0.10.2",
-        "@opentelemetry/context-base": "^0.10.2",
-        "@opentelemetry/core": "^0.10.2",
-        "@opentelemetry/resources": "^0.10.2"
+        "@opentelemetry/api": "^0.11.0",
+        "@opentelemetry/context-base": "^0.11.0",
+        "@opentelemetry/core": "^0.11.0",
+        "@opentelemetry/resources": "^0.11.0",
+        "@opentelemetry/semantic-conventions": "^0.11.0"
       }
-    },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
-    },
-    "agent-base": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
-      "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
-      "requires": {
-        "debug": "4"
-      }
-    },
-    "bignumber.js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
       "requires": {
-        "ms": "^2.1.1"
-      }
-    },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
-    },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "gaxios": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.3.4.tgz",
-      "integrity": "sha512-US8UMj8C5pRnao3Zykc4AAVr+cffoNKRTg9Rsf2GiuZCW69vgJj38VK2PzlPuQU73FZ/nTk9/Av6/JGcE1N9vA==",
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.3.0"
-      }
-    },
-    "gcp-metadata": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.5.0.tgz",
-      "integrity": "sha512-ZQf+DLZ5aKcRpLzYUyBS3yo3N0JSa82lNDO8rj3nMSlovLcz2riKFBsYgDzeXcv75oo5eqB2lx+B14UvPoCRnA==",
-      "requires": {
-        "gaxios": "^2.1.0",
-        "json-bigint": "^0.3.0"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
-      }
-    },
-    "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
-    },
-    "json-bigint": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.1.tgz",
-      "integrity": "sha512-DGWnSzmusIreWlEupsUelHrhwmPPE+FiQvg+drKfk2p+bdEYa5mp4PJ8JsCWqae0M2jQNb0HPvnwvf1qOTThzQ==",
-      "requires": {
-        "bignumber.js": "^9.0.0"
+        "ms": "2.1.2"
       }
     },
     "module-details-from-path": {
@@ -4992,11 +4893,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -5020,6 +4916,11 @@
       "requires": {
         "path-parse": "^1.0.6"
       }
+    },
+    "semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     }
   }
 }

--- a/samples/trace/package.json
+++ b/samples/trace/package.json
@@ -12,8 +12,8 @@
   "repository": "GoogleCloudPlatform/opentelemetry-operations-js",
   "dependencies": {
     "@google-cloud/opentelemetry-cloud-trace-exporter": "file:../../packages/opentelemetry-cloud-trace-exporter",
-    "@opentelemetry/api": "0.10.2",
-    "@opentelemetry/node": "0.10.2",
-    "@opentelemetry/tracing": "0.10.2"
+    "@opentelemetry/api": "^0.11.0",
+    "@opentelemetry/node": "^0.11.0",
+    "@opentelemetry/tracing": "^0.11.0"
   }
 }


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue/feature](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #165

----

It is no longer possible to support back to v0.8.0 because of a fair number of breaking changes. As suggested in #165, this upgrades all peer dependencies to `^0.11.0`. The next release will be a "major" release (v0.5.0 per semantic versioning < v1.0.0) because of these breaking changes.

Fixes for new opentelemetry version:

- `resource.labels -> resource.attributes`
- `OTPoint` is now generic `OTPoint<PointValueType>`
- `meter.collect()` needs to now be awaited in tests. I'm not sure if it was previously not async, but the tests fail if without waiting for the promise to resolve.
- `OTMetricKind.OBSERVER` was removed https://github.com/open-telemetry/opentelemetry-js/issues/1146
- **`SumObserver` appears to now be `CUMULATIVE`**
  * I don't think this requires any other changes on our side, but would be great to get a second opinion
  * Another effect of this is that we now get `startTime`
- `HttpTextPropagator -> TextMapPropagator`