### PR TITLE
fix(tracer): add http mapping attributes to transformer

### DIFF
--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -158,7 +158,6 @@ const HTTP_ATTRIBUTE_MAPPING: {[key: string]: string} = {
   'http.request_content_length': '/http/request/size',
   'http.response_content_length': '/http/response/size',
   'http.route': '/http/route',
-  'http.path': '/http/path',
 };
 function transformAttributeNames(attributes: ot.Attributes): ot.Attributes {
   const out: ot.Attributes = {};

--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -151,21 +151,13 @@ function valueToAttributeValue(
 const HTTP_ATTRIBUTE_MAPPING: {[key: string]: string} = {
   'http.method': '/http/method',
   'http.url': '/http/url',
-  'http.target': '/http/target',
   'http.host': '/http/host',
   'http.scheme': '/http/client_protocol',
   'http.status_code': '/http/status_code',
-  'http.flavor': '/http/flavor',
   'http.user_agent': '/http/user_agent',
-  'http.request_content_length': '/http/request_content_length',
-  'http.request_content_length_uncompressed':
-    '/http/request_content_length_uncompressed',
-  'http.response_content_length': '/http/response_content_length',
-  'http.response_content_length_uncompressed':
-    '/http/response_content_length_uncompressed',
-  'http.server_name': '/http/server_name',
+  'http.request_content_length': '/http/request/size',
+  'http.response_content_length': '/http/response/size',
   'http.route': '/http/route',
-  'http.client_ip': '/http/client_ip',
   'http.path': '/http/path',
 };
 function transformAttributeNames(attributes: ot.Attributes): ot.Attributes {

--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -102,8 +102,8 @@ function transformAttributes(
     serviceAttributes,
     resource.attributes
   );
-
-  const attributeMap = transformAttributeValues(attributes);
+  const changedAttributes = transformAttributeNames(attributes);
+  const attributeMap = transformAttributeValues(changedAttributes);
   return {
     attributeMap,
     // @todo get dropped attribute count from sdk ReadableSpan
@@ -146,4 +146,36 @@ function valueToAttributeValue(
     default:
       return {};
   }
+}
+
+const HTTP_ATTRIBUTE_MAPPING: {[key: string]: string} = {
+  'http.method': '/http/method',
+  'http.url': '/http/url',
+  'http.target': '/http/target',
+  'http.host': '/http/host',
+  'http.scheme': '/http/client_protocol',
+  'http.status_code': '/http/status_code',
+  'http.flavor': '/http/flavor',
+  'http.user_agent': '/http/user_agent',
+  'http.request_content_length': '/http/request_content_length',
+  'http.request_content_length_uncompressed':
+    '/http/request_content_length_uncompressed',
+  'http.response_content_length': '/http/response_content_length',
+  'http.response_content_length_uncompressed':
+    '/http/response_content_length_uncompressed',
+  'http.server_name': '/http/server_name',
+  'http.route': '/http/route',
+  'http.client_ip': '/http/client_ip',
+  'http.path': '/http/path',
+};
+function transformAttributeNames(attributes: ot.Attributes): ot.Attributes {
+  const out: ot.Attributes = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (HTTP_ATTRIBUTE_MAPPING[key]) {
+      out[HTTP_ATTRIBUTE_MAPPING[key]] = value;
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
 }

--- a/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
@@ -129,6 +129,27 @@ describe('transform', () => {
     assert.deepStrictEqual(result.attributes!.droppedAttributesCount, 0);
   });
 
+  it('should transform http attributes', () => {
+    readableSpan.attributes['http.method'] = 'POST';
+    readableSpan.attributes['http.scheme'] = 'https';
+    readableSpan.attributes['http.host'] = 'example.com';
+
+    const result = transformer(readableSpan);
+
+    assert.deepStrictEqual(result.attributes!.attributeMap!['/http/method'], {
+      stringValue: {value: 'POST'},
+    });
+    assert.deepStrictEqual(
+      result.attributes!.attributeMap!['/http/client_protocol'],
+      {
+        stringValue: {value: 'https'},
+      }
+    );
+    assert.deepStrictEqual(result.attributes!.attributeMap!['/http/host'], {
+      stringValue: {value: 'example.com'},
+    });
+  });
+
   it('should drop unknown attribute types', () => {
     // @ts-expect-error testing behavior with unsupported type
     readableSpan.attributes.testUnknownType = {message: 'dropped'};


### PR DESCRIPTION
Fixes #214
list of all http attributes are here: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md#common-attributes
I tried to add all of them
also note that in python they did it in this way:
https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/blob/c3772de4cf50950f1d51685ff3bbf0e46ee026df/opentelemetry-exporter-google-cloud/src/opentelemetry/exporter/cloud_trace/__init__.py#L367