### PR TITLE
Change import for NoopLogger

### DIFF
--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ExportResult, ExportResultCode, NoopLogger} from '@opentelemetry/core';
+import {ExportResult, ExportResultCode} from '@opentelemetry/core';
 import {ReadableSpan, SpanExporter} from '@opentelemetry/tracing';
-import {Logger} from '@opentelemetry/api';
+import {Logger, NoopLogger} from '@opentelemetry/api';
 import * as protoloader from '@grpc/proto-loader';
 import * as protofiles from 'google-proto-files';
 import * as grpc from '@grpc/grpc-js';


### PR DESCRIPTION
It appears that OT removed the `NoopLogger` export from `core`:
https://github.com/open-telemetry/opentelemetry-js/pull/1746

This prevents app crashes when a logger is not provided. (Don't have time to file a full issue/etc but figured this might help regardless; sorry!)

---

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue/feature](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here>