### PR TITLE
chore: configure renovate to only pin devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3354,6 +3354,7 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -4060,6 +4061,7 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -4584,6 +4586,7 @@
       "integrity": "sha512-akCrLDWfbdAWkMLBxJEeWTdNsjML+dt5YgOI4gJ53vuO0vrmYQkUPxa6j6V65s9CcePIr2SSWqjT2EcrNseryQ==",
       "dev": true,
       "dependencies": {
+        "encoding": "^0.1.12",
         "minipass": "^3.1.0",
         "minipass-sized": "^1.0.3",
         "minizlib": "^2.0.0"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":pinOnlyDevDependencies"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
I think [`:pinOnlyDevDependencies`](https://docs.renovatebot.com/presets-default/#pinonlydevdependencies) is the best way to go with renovate. It ensure that devDependencies are a specific version (also in lockfile, but [renovate recommends doing both](https://docs.renovatebot.com/dependency-pinning/#pinning-dependencies-and-lock-files)) but we can keep semver ranges for dependencies and especially peerDependencies, which users would be installing.