### PR TITLE
upgrade dependencies to 0.21.0, fix breakages

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/package-lock.json
+++ b/packages/opentelemetry-cloud-monitoring-exporter/package-lock.json
@@ -9,15 +9,16 @@
 			"version": "0.9.0",
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^0.21.0",
 				"google-auth-library": "^7.0.0",
 				"googleapis": "^76.0.0"
 			},
 			"devDependencies": {
-				"@opentelemetry/api": "0.18.1",
-				"@opentelemetry/api-metrics": "0.18.2",
-				"@opentelemetry/core": "0.18.2",
-				"@opentelemetry/metrics": "0.18.2",
-				"@opentelemetry/resources": "0.18.2",
+				"@opentelemetry/api": "0.21.0",
+				"@opentelemetry/api-metrics": "0.21.0",
+				"@opentelemetry/core": "0.21.0",
+				"@opentelemetry/metrics": "0.21.0",
+				"@opentelemetry/resources": "0.21.0",
 				"@types/mocha": "7.0.2",
 				"@types/nock": "11.1.0",
 				"@types/node": "14.14.41",
@@ -36,10 +37,10 @@
 				"node": ">=10"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^0.18.0",
-				"@opentelemetry/core": "^0.18.0",
-				"@opentelemetry/metrics": "^0.18.0",
-				"@opentelemetry/resources": "^0.18.0"
+				"@opentelemetry/api": "^0.21.0",
+				"@opentelemetry/core": "^0.21.0",
+				"@opentelemetry/metrics": "^0.21.0",
+				"@opentelemetry/resources": "^0.21.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -501,64 +502,80 @@
 			}
 		},
 		"node_modules/@opentelemetry/api": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.18.1.tgz",
-			"integrity": "sha512-pKNxHe3AJ5T2N5G3AlT9gx6FyF5K2FS9ZNc+FipC+f1CpVF/EY+JHTJ749dnM2kWIgZTbDJFiGMuc0FYjNSCOg==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.21.0.tgz",
+			"integrity": "sha512-Q7hHb3nidPgnBS2fi+y3K64F3EV48d9v09/6EtigIgVF43NFNhw/dboDKC7gECEkbTwuvFeLCbwKs9JaC8LDEw==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/api-metrics": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.18.2.tgz",
-			"integrity": "sha512-yoC1Bg3GRAf2xXAVsE6Wf54rs351XO694PsnvWGRXITJQq84yLru7Qq12w6w3N5TTyGzW6oZtqXpGWe5Im/dNQ==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.21.0.tgz",
+			"integrity": "sha512-s3mhqJdV04DFL59lhp7wR5UMCpJu6BN7PWJRokjXs/St5NIsYjWt5G0OlsrN58/OgSIVl2pdPbVG2QhASvhSpw==",
 			"dev": true,
-			"dependencies": {
-				"@opentelemetry/api": "^0.18.1"
-			},
 			"engines": {
 				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^0.21.0"
 			}
 		},
 		"node_modules/@opentelemetry/core": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.18.2.tgz",
-			"integrity": "sha512-WG8veOEd8xZHuBaOHddzWQg5yj794lrEPAe6W1qI0YkV7pyqYXvhJdCxOU5Lyo1SWzTAjI5xrCUQ9J2WlrqzYA==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.21.0.tgz",
+			"integrity": "sha512-sZZQThBuqhCdBPgzPq4y9L4dhnpXXCCEqNsR6IUmMc/kQ8Bcw3lmI5fymLlliSt+lnTc26xJPVKZlwoQfwhThg==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/api": "^0.18.1",
+				"@opentelemetry/semantic-conventions": "0.21.0",
 				"semver": "^7.1.3"
 			},
 			"engines": {
 				"node": ">=8.5.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^0.21.0"
 			}
 		},
 		"node_modules/@opentelemetry/metrics": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/metrics/-/metrics-0.18.2.tgz",
-			"integrity": "sha512-Fp+1rmey1xMgXAFpBp3C61bnAVPlQFtPBlm7oSSYCsjwqBtDEcaT8EdY/c06Vo6k+aXTuMw1BFNgTHrwDtNGlg==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/metrics/-/metrics-0.21.0.tgz",
+			"integrity": "sha512-UckbV+09LdX6R4u2Fb5O5447Se/AkwZZdJt9sjqUqbre4971JdMpCGyia+SZ9lSMHQTzWuh55UwS+Q0l4AXU1w==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/api": "^0.18.1",
-				"@opentelemetry/api-metrics": "^0.18.2",
-				"@opentelemetry/core": "^0.18.2",
-				"@opentelemetry/resources": "^0.18.2",
+				"@opentelemetry/api-metrics": "0.21.0",
+				"@opentelemetry/core": "0.21.0",
+				"@opentelemetry/resources": "0.21.0",
 				"lodash.merge": "^4.6.2"
 			},
 			"engines": {
 				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^0.21.0"
 			}
 		},
 		"node_modules/@opentelemetry/resources": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.18.2.tgz",
-			"integrity": "sha512-EBPqFsreXgFaqkMmWCE8vh6pFhbWExRHSO24qSeGhxFmM5SQP/D1jJqMp/jVUSmrF97fPkMS0aEH5z7NOWdxQA==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.21.0.tgz",
+			"integrity": "sha512-xQUL2/2npP/isH8sbOSdynIRWmlM6p02L9Ex8x/BhUuSkGrMoxO2ezLPPYnfYam1py6ubaz8m1C54O2IRCmgQQ==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/api": "^0.18.1",
-				"@opentelemetry/core": "^0.18.2"
+				"@opentelemetry/core": "0.21.0",
+				"@opentelemetry/semantic-conventions": "0.21.0"
 			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^0.21.0"
+			}
+		},
+		"node_modules/@opentelemetry/semantic-conventions": {
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.21.0.tgz",
+			"integrity": "sha512-qQtZJ8Q+bO/gemBELsZbz5s//tNnyc+mQD/0RHc77XhI6ZBb+tprU6KN/7l0fl5z29smmai0hcJ9UNILC/7nIw==",
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -6402,52 +6419,54 @@
 			}
 		},
 		"@opentelemetry/api": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.18.1.tgz",
-			"integrity": "sha512-pKNxHe3AJ5T2N5G3AlT9gx6FyF5K2FS9ZNc+FipC+f1CpVF/EY+JHTJ749dnM2kWIgZTbDJFiGMuc0FYjNSCOg==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.21.0.tgz",
+			"integrity": "sha512-Q7hHb3nidPgnBS2fi+y3K64F3EV48d9v09/6EtigIgVF43NFNhw/dboDKC7gECEkbTwuvFeLCbwKs9JaC8LDEw==",
 			"dev": true
 		},
 		"@opentelemetry/api-metrics": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.18.2.tgz",
-			"integrity": "sha512-yoC1Bg3GRAf2xXAVsE6Wf54rs351XO694PsnvWGRXITJQq84yLru7Qq12w6w3N5TTyGzW6oZtqXpGWe5Im/dNQ==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.21.0.tgz",
+			"integrity": "sha512-s3mhqJdV04DFL59lhp7wR5UMCpJu6BN7PWJRokjXs/St5NIsYjWt5G0OlsrN58/OgSIVl2pdPbVG2QhASvhSpw==",
 			"dev": true,
-			"requires": {
-				"@opentelemetry/api": "^0.18.1"
-			}
+			"requires": {}
 		},
 		"@opentelemetry/core": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.18.2.tgz",
-			"integrity": "sha512-WG8veOEd8xZHuBaOHddzWQg5yj794lrEPAe6W1qI0YkV7pyqYXvhJdCxOU5Lyo1SWzTAjI5xrCUQ9J2WlrqzYA==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.21.0.tgz",
+			"integrity": "sha512-sZZQThBuqhCdBPgzPq4y9L4dhnpXXCCEqNsR6IUmMc/kQ8Bcw3lmI5fymLlliSt+lnTc26xJPVKZlwoQfwhThg==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/api": "^0.18.1",
+				"@opentelemetry/semantic-conventions": "0.21.0",
 				"semver": "^7.1.3"
 			}
 		},
 		"@opentelemetry/metrics": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/metrics/-/metrics-0.18.2.tgz",
-			"integrity": "sha512-Fp+1rmey1xMgXAFpBp3C61bnAVPlQFtPBlm7oSSYCsjwqBtDEcaT8EdY/c06Vo6k+aXTuMw1BFNgTHrwDtNGlg==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/metrics/-/metrics-0.21.0.tgz",
+			"integrity": "sha512-UckbV+09LdX6R4u2Fb5O5447Se/AkwZZdJt9sjqUqbre4971JdMpCGyia+SZ9lSMHQTzWuh55UwS+Q0l4AXU1w==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/api": "^0.18.1",
-				"@opentelemetry/api-metrics": "^0.18.2",
-				"@opentelemetry/core": "^0.18.2",
-				"@opentelemetry/resources": "^0.18.2",
+				"@opentelemetry/api-metrics": "0.21.0",
+				"@opentelemetry/core": "0.21.0",
+				"@opentelemetry/resources": "0.21.0",
 				"lodash.merge": "^4.6.2"
 			}
 		},
 		"@opentelemetry/resources": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.18.2.tgz",
-			"integrity": "sha512-EBPqFsreXgFaqkMmWCE8vh6pFhbWExRHSO24qSeGhxFmM5SQP/D1jJqMp/jVUSmrF97fPkMS0aEH5z7NOWdxQA==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.21.0.tgz",
+			"integrity": "sha512-xQUL2/2npP/isH8sbOSdynIRWmlM6p02L9Ex8x/BhUuSkGrMoxO2ezLPPYnfYam1py6ubaz8m1C54O2IRCmgQQ==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/api": "^0.18.1",
-				"@opentelemetry/core": "^0.18.2"
+				"@opentelemetry/core": "0.21.0",
+				"@opentelemetry/semantic-conventions": "0.21.0"
 			}
+		},
+		"@opentelemetry/semantic-conventions": {
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.21.0.tgz",
+			"integrity": "sha512-qQtZJ8Q+bO/gemBELsZbz5s//tNnyc+mQD/0RHc77XhI6ZBb+tprU6KN/7l0fl5z29smmai0hcJ9UNILC/7nIw=="
 		},
 		"@sindresorhus/is": {
 			"version": "0.14.0",

--- a/packages/opentelemetry-cloud-monitoring-exporter/package.json
+++ b/packages/opentelemetry-cloud-monitoring-exporter/package.json
@@ -38,11 +38,11 @@
     "registry": "https://wombat-dressing-room.appspot.com"
   },
   "devDependencies": {
-    "@opentelemetry/api": "0.18.1",
-    "@opentelemetry/api-metrics": "0.18.2",
-    "@opentelemetry/core": "0.18.2",
-    "@opentelemetry/metrics": "0.18.2",
-    "@opentelemetry/resources": "0.18.2",
+    "@opentelemetry/api": "0.21.0",
+    "@opentelemetry/api-metrics": "0.21.0",
+    "@opentelemetry/core": "0.21.0",
+    "@opentelemetry/metrics": "0.21.0",
+    "@opentelemetry/resources": "0.21.0",
     "@types/mocha": "7.0.2",
     "@types/nock": "11.1.0",
     "@types/node": "14.14.41",
@@ -58,13 +58,14 @@
     "typescript": "4.2.4"
   },
   "dependencies": {
+    "@opentelemetry/semantic-conventions": "^0.21.0",
     "google-auth-library": "^7.0.0",
     "googleapis": "^76.0.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^0.18.0",
-    "@opentelemetry/core": "^0.18.0",
-    "@opentelemetry/metrics": "^0.18.0",
-    "@opentelemetry/resources": "^0.18.0"
+    "@opentelemetry/api": "^0.21.0",
+    "@opentelemetry/core": "^0.21.0",
+    "@opentelemetry/metrics": "^0.21.0",
+    "@opentelemetry/resources": "^0.21.0"
   }
 }

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -21,11 +21,8 @@ import {
   PointValueType,
 } from '@opentelemetry/metrics';
 import {ValueType as OTValueType} from '@opentelemetry/api-metrics';
-import {
-  Resource,
-  CLOUD_RESOURCE,
-  HOST_RESOURCE,
-} from '@opentelemetry/resources';
+import {Resource} from '@opentelemetry/resources';
+import {ResourceAttributes} from '@opentelemetry/semantic-conventions';
 import {
   MetricDescriptor,
   MetricKind,
@@ -147,7 +144,7 @@ function transformResource(
     }
     if (
       type === AWS_EC2_INSTANCE &&
-      templateResource.labels[key] === CLOUD_RESOURCE.REGION
+      templateResource.labels[key] === ResourceAttributes.CLOUD_REGION
     ) {
       labels[key] = `${AWS_REGION_VALUE_PREFIX}${resourceValue}`;
     } else {
@@ -163,22 +160,24 @@ function transformResource(
  * @param resource
  */
 function getTypeAndMappings(resource: Resource): MonitoredResource {
-  const cloudProvider = `${resource.attributes[CLOUD_RESOURCE.PROVIDER]}`;
+  const cloudProvider = `${
+    resource.attributes[ResourceAttributes.CLOUD_PROVIDER]
+  }`;
   if (cloudProvider === 'gcp') {
     return {
       type: GCP_GCE_INSTANCE,
       labels: {
-        instance_id: HOST_RESOURCE.ID,
-        zone: CLOUD_RESOURCE.ZONE,
+        instance_id: ResourceAttributes.HOST_ID,
+        zone: ResourceAttributes.CLOUD_AVAILABILITY_ZONE,
       },
     };
   } else if (cloudProvider === 'aws') {
     return {
       type: AWS_EC2_INSTANCE,
       labels: {
-        instance_id: HOST_RESOURCE.ID,
-        region: CLOUD_RESOURCE.REGION,
-        aws_account: CLOUD_RESOURCE.ACCOUNT_ID,
+        instance_id: ResourceAttributes.HOST_ID,
+        region: ResourceAttributes.CLOUD_REGION,
+        aws_account: ResourceAttributes.CLOUD_ACCOUNT_ID,
       },
     };
   }

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -26,6 +26,7 @@ import {
   MeterProvider,
   Histogram,
 } from '@opentelemetry/metrics';
+import {ResourceAttributes} from '@opentelemetry/semantic-conventions';
 import {ValueType as OTValueType, Labels} from '@opentelemetry/api-metrics';
 import {MetricKind, ValueType, MetricDescriptor} from '../src/types';
 import {Resource} from '@opentelemetry/resources';
@@ -149,10 +150,10 @@ describe('transform', () => {
 
   describe('TimeSeries', () => {
     const mockAwsResource = {
-      'cloud.provider': 'aws',
-      'host.id': 'host_id',
-      'cloud.region': 'my-region',
-      'cloud.account.id': '12345',
+      [ResourceAttributes.CLOUD_PROVIDER]: 'aws',
+      [ResourceAttributes.HOST_ID]: 'host_id',
+      [ResourceAttributes.CLOUD_REGION]: 'my-region',
+      [ResourceAttributes.CLOUD_ACCOUNT_ID]: '12345',
     };
     const mockAwsMonitoredResource = {
       type: 'aws_ec2_instance',
@@ -164,9 +165,9 @@ describe('transform', () => {
       },
     };
     const mockGCResource = {
-      'cloud.provider': 'gcp',
-      'host.id': 'host_id',
-      'cloud.zone': 'my-zone',
+      [ResourceAttributes.CLOUD_PROVIDER]: 'gcp',
+      [ResourceAttributes.HOST_ID]: 'host_id',
+      [ResourceAttributes.CLOUD_AVAILABILITY_ZONE]: 'my-zone',
     };
     const mockGCMonitoredResource = {
       type: 'gce_instance',

--- a/packages/opentelemetry-cloud-trace-exporter/package-lock.json
+++ b/packages/opentelemetry-cloud-trace-exporter/package-lock.json
@@ -15,9 +15,9 @@
 				"google-proto-files": "^2.1.0"
 			},
 			"devDependencies": {
-				"@opentelemetry/api": "0.18.1",
-				"@opentelemetry/resources": "0.18.2",
-				"@opentelemetry/tracing": "0.18.2",
+				"@opentelemetry/api": "0.21.0",
+				"@opentelemetry/resources": "0.21.0",
+				"@opentelemetry/tracing": "0.21.0",
 				"@types/mocha": "7.0.2",
 				"@types/node": "14.14.41",
 				"@types/sinon": "10.0.0",
@@ -36,10 +36,10 @@
 				"node": ">=10"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^0.18.0",
-				"@opentelemetry/core": "^0.18.0",
-				"@opentelemetry/resources": "^0.18.0",
-				"@opentelemetry/tracing": "^0.18.0"
+				"@opentelemetry/api": "^0.21.0",
+				"@opentelemetry/core": "^0.21.0",
+				"@opentelemetry/resources": "^0.21.0",
+				"@opentelemetry/tracing": "^0.21.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -568,23 +568,26 @@
 			}
 		},
 		"node_modules/@opentelemetry/api": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.18.1.tgz",
-			"integrity": "sha512-pKNxHe3AJ5T2N5G3AlT9gx6FyF5K2FS9ZNc+FipC+f1CpVF/EY+JHTJ749dnM2kWIgZTbDJFiGMuc0FYjNSCOg==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.21.0.tgz",
+			"integrity": "sha512-Q7hHb3nidPgnBS2fi+y3K64F3EV48d9v09/6EtigIgVF43NFNhw/dboDKC7gECEkbTwuvFeLCbwKs9JaC8LDEw==",
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/core": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.18.2.tgz",
-			"integrity": "sha512-WG8veOEd8xZHuBaOHddzWQg5yj794lrEPAe6W1qI0YkV7pyqYXvhJdCxOU5Lyo1SWzTAjI5xrCUQ9J2WlrqzYA==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.21.0.tgz",
+			"integrity": "sha512-sZZQThBuqhCdBPgzPq4y9L4dhnpXXCCEqNsR6IUmMc/kQ8Bcw3lmI5fymLlliSt+lnTc26xJPVKZlwoQfwhThg==",
 			"dependencies": {
-				"@opentelemetry/api": "^0.18.1",
+				"@opentelemetry/semantic-conventions": "0.21.0",
 				"semver": "^7.1.3"
 			},
 			"engines": {
 				"node": ">=8.5.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^0.21.0"
 			}
 		},
 		"node_modules/@opentelemetry/core/node_modules/semver": {
@@ -602,41 +605,45 @@
 			}
 		},
 		"node_modules/@opentelemetry/resources": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.18.2.tgz",
-			"integrity": "sha512-EBPqFsreXgFaqkMmWCE8vh6pFhbWExRHSO24qSeGhxFmM5SQP/D1jJqMp/jVUSmrF97fPkMS0aEH5z7NOWdxQA==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.21.0.tgz",
+			"integrity": "sha512-xQUL2/2npP/isH8sbOSdynIRWmlM6p02L9Ex8x/BhUuSkGrMoxO2ezLPPYnfYam1py6ubaz8m1C54O2IRCmgQQ==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/api": "^0.18.1",
-				"@opentelemetry/core": "^0.18.2"
+				"@opentelemetry/core": "0.21.0",
+				"@opentelemetry/semantic-conventions": "0.21.0"
 			},
 			"engines": {
 				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^0.21.0"
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.18.2.tgz",
-			"integrity": "sha512-+0P+PrP9qSFVaayNdek4P1OAGE+PEl2SsufuHDRmUpOY25Wzjo7Atyar56Trjc32jkNy4lID6ZFT6BahsR9P9A==",
-			"dev": true,
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.21.0.tgz",
+			"integrity": "sha512-qQtZJ8Q+bO/gemBELsZbz5s//tNnyc+mQD/0RHc77XhI6ZBb+tprU6KN/7l0fl5z29smmai0hcJ9UNILC/7nIw==",
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/tracing": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.18.2.tgz",
-			"integrity": "sha512-IQSu+NwMhX8O9Wkjc4HjNqs/aKfkcInCE3dQuAOBBec/saLrM6jqd+Fa5QUzg03WMOqpDuZm5KTkr5+6DUrr0g==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.21.0.tgz",
+			"integrity": "sha512-6+2pfFpu7Yo2DwmBK9sHDUSIL7UshcEMwDF6+LghGK68ILRaEMqqBPgKarjhFH9ERgJB9GOkJ2snK96qIzMZNA==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/api": "^0.18.1",
-				"@opentelemetry/core": "^0.18.2",
-				"@opentelemetry/resources": "^0.18.2",
-				"@opentelemetry/semantic-conventions": "^0.18.2",
+				"@opentelemetry/core": "0.21.0",
+				"@opentelemetry/resources": "0.21.0",
+				"@opentelemetry/semantic-conventions": "0.21.0",
 				"lodash.merge": "^4.6.2"
 			},
 			"engines": {
 				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^0.21.0"
 			}
 		},
 		"node_modules/@protobufjs/aspromise": {
@@ -6583,16 +6590,16 @@
 			}
 		},
 		"@opentelemetry/api": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.18.1.tgz",
-			"integrity": "sha512-pKNxHe3AJ5T2N5G3AlT9gx6FyF5K2FS9ZNc+FipC+f1CpVF/EY+JHTJ749dnM2kWIgZTbDJFiGMuc0FYjNSCOg=="
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.21.0.tgz",
+			"integrity": "sha512-Q7hHb3nidPgnBS2fi+y3K64F3EV48d9v09/6EtigIgVF43NFNhw/dboDKC7gECEkbTwuvFeLCbwKs9JaC8LDEw=="
 		},
 		"@opentelemetry/core": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.18.2.tgz",
-			"integrity": "sha512-WG8veOEd8xZHuBaOHddzWQg5yj794lrEPAe6W1qI0YkV7pyqYXvhJdCxOU5Lyo1SWzTAjI5xrCUQ9J2WlrqzYA==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.21.0.tgz",
+			"integrity": "sha512-sZZQThBuqhCdBPgzPq4y9L4dhnpXXCCEqNsR6IUmMc/kQ8Bcw3lmI5fymLlliSt+lnTc26xJPVKZlwoQfwhThg==",
 			"requires": {
-				"@opentelemetry/api": "^0.18.1",
+				"@opentelemetry/semantic-conventions": "0.21.0",
 				"semver": "^7.1.3"
 			},
 			"dependencies": {
@@ -6607,31 +6614,29 @@
 			}
 		},
 		"@opentelemetry/resources": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.18.2.tgz",
-			"integrity": "sha512-EBPqFsreXgFaqkMmWCE8vh6pFhbWExRHSO24qSeGhxFmM5SQP/D1jJqMp/jVUSmrF97fPkMS0aEH5z7NOWdxQA==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.21.0.tgz",
+			"integrity": "sha512-xQUL2/2npP/isH8sbOSdynIRWmlM6p02L9Ex8x/BhUuSkGrMoxO2ezLPPYnfYam1py6ubaz8m1C54O2IRCmgQQ==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/api": "^0.18.1",
-				"@opentelemetry/core": "^0.18.2"
+				"@opentelemetry/core": "0.21.0",
+				"@opentelemetry/semantic-conventions": "0.21.0"
 			}
 		},
 		"@opentelemetry/semantic-conventions": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.18.2.tgz",
-			"integrity": "sha512-+0P+PrP9qSFVaayNdek4P1OAGE+PEl2SsufuHDRmUpOY25Wzjo7Atyar56Trjc32jkNy4lID6ZFT6BahsR9P9A==",
-			"dev": true
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.21.0.tgz",
+			"integrity": "sha512-qQtZJ8Q+bO/gemBELsZbz5s//tNnyc+mQD/0RHc77XhI6ZBb+tprU6KN/7l0fl5z29smmai0hcJ9UNILC/7nIw=="
 		},
 		"@opentelemetry/tracing": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.18.2.tgz",
-			"integrity": "sha512-IQSu+NwMhX8O9Wkjc4HjNqs/aKfkcInCE3dQuAOBBec/saLrM6jqd+Fa5QUzg03WMOqpDuZm5KTkr5+6DUrr0g==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.21.0.tgz",
+			"integrity": "sha512-6+2pfFpu7Yo2DwmBK9sHDUSIL7UshcEMwDF6+LghGK68ILRaEMqqBPgKarjhFH9ERgJB9GOkJ2snK96qIzMZNA==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/api": "^0.18.1",
-				"@opentelemetry/core": "^0.18.2",
-				"@opentelemetry/resources": "^0.18.2",
-				"@opentelemetry/semantic-conventions": "^0.18.2",
+				"@opentelemetry/core": "0.21.0",
+				"@opentelemetry/resources": "0.21.0",
+				"@opentelemetry/semantic-conventions": "0.21.0",
 				"lodash.merge": "^4.6.2"
 			}
 		},

--- a/packages/opentelemetry-cloud-trace-exporter/package.json
+++ b/packages/opentelemetry-cloud-trace-exporter/package.json
@@ -38,9 +38,9 @@
     "registry": "https://wombat-dressing-room.appspot.com"
   },
   "devDependencies": {
-    "@opentelemetry/api": "0.18.1",
-    "@opentelemetry/resources": "0.18.2",
-    "@opentelemetry/tracing": "0.18.2",
+    "@opentelemetry/api": "0.21.0",
+    "@opentelemetry/resources": "0.21.0",
+    "@opentelemetry/tracing": "0.21.0",
     "@types/mocha": "7.0.2",
     "@types/node": "14.14.41",
     "@types/sinon": "10.0.0",
@@ -62,9 +62,9 @@
     "google-proto-files": "^2.1.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^0.18.0",
-    "@opentelemetry/core": "^0.18.0",
-    "@opentelemetry/resources": "^0.18.0",
-    "@opentelemetry/tracing": "^0.18.0"
+    "@opentelemetry/api": "^0.21.0",
+    "@opentelemetry/core": "^0.21.0",
+    "@opentelemetry/resources": "^0.21.0",
+    "@opentelemetry/tracing": "^0.21.0"
   }
 }

--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -51,9 +51,11 @@ export function getReadableSpanTransformer(
       },
       endTime: transformTime(span.endTime),
       startTime: transformTime(span.startTime),
-      name: `projects/${projectId}/traces/${span.spanContext.traceId}/spans/${span.spanContext.spanId}`,
-      spanId: span.spanContext.spanId,
-      sameProcessAsParentSpan: {value: !span.spanContext.isRemote},
+      name: `projects/${projectId}/traces/${span.spanContext().traceId}/spans/${
+        span.spanContext().spanId
+      }`,
+      spanId: span.spanContext().spanId,
+      sameProcessAsParentSpan: {value: !span.spanContext().isRemote},
       status: transformStatus(span.status),
       timeEvents: {
         timeEvent: span.events.map(e => ({

--- a/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
@@ -182,12 +182,12 @@ describe('Google Cloud Trace Exporter', () => {
         kind: types.SpanKind.CLIENT,
         links: [],
         name: 'my-span',
-        spanContext: {
+        spanContext: () => ({
           traceId: 'd4cda95b652f4a1592b449d5929fda1b',
           spanId: '6e0c63257de34c92',
           traceFlags: TraceFlags.NONE,
           isRemote: true,
-        },
+        }),
         status: {code: types.SpanStatusCode.OK},
         resource: Resource.empty(),
         instrumentationLibrary: {name: 'default', version: '0.0.1'},
@@ -232,12 +232,12 @@ describe('Google Cloud Trace Exporter', () => {
         kind: types.SpanKind.CLIENT,
         links: [],
         name: 'my-span',
-        spanContext: {
+        spanContext: () => ({
           traceId: 'd4cda95b652f4a1592b449d5929fda1b',
           spanId: '6e0c63257de34c92',
           traceFlags: TraceFlags.NONE,
           isRemote: true,
-        },
+        }),
         status: {code: types.SpanStatusCode.OK},
         resource: Resource.empty(),
         instrumentationLibrary: {name: 'default', version: '0.0.1'},
@@ -272,12 +272,12 @@ describe('Google Cloud Trace Exporter', () => {
         kind: types.SpanKind.CLIENT,
         links: [],
         name: 'my-span',
-        spanContext: {
+        spanContext: () => ({
           traceId: 'd4cda95b652f4a1592b449d5929fda1b',
           spanId: '6e0c63257de34c92',
           traceFlags: TraceFlags.NONE,
           isRemote: true,
-        },
+        }),
         status: {code: types.SpanStatusCode.OK},
         resource: Resource.empty(),
         instrumentationLibrary: {name: 'default', version: '0.0.1'},
@@ -306,12 +306,12 @@ describe('Google Cloud Trace Exporter', () => {
         kind: types.SpanKind.CLIENT,
         links: [],
         name: 'my-span',
-        spanContext: {
+        spanContext: () => ({
           traceId: 'd4cda95b652f4a1592b449d5929fda1b',
           spanId: '6e0c63257de34c92',
           traceFlags: TraceFlags.NONE,
           isRemote: true,
-        },
+        }),
         status: {code: types.SpanStatusCode.OK},
         resource: Resource.empty(),
         instrumentationLibrary: {name: 'default', version: '0.0.1'},
@@ -338,12 +338,12 @@ describe('Google Cloud Trace Exporter', () => {
         kind: types.SpanKind.CLIENT,
         links: [],
         name: 'my-span',
-        spanContext: {
+        spanContext: () => ({
           traceId: 'd4cda95b652f4a1592b449d5929fda1b',
           spanId: '6e0c63257de34c92',
           traceFlags: TraceFlags.NONE,
           isRemote: true,
-        },
+        }),
         status: {code: types.SpanStatusCode.OK},
         resource: Resource.empty(),
         instrumentationLibrary: {name: 'default', version: '0.0.1'},

--- a/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
@@ -45,7 +45,7 @@ describe('transform', () => {
       kind: api.SpanKind.CLIENT,
       links: [],
       name: 'my-span',
-      spanContext,
+      spanContext: () => spanContext,
       status: {code: api.SpanStatusCode.OK},
       resource: new Resource({
         service: 'ui',
@@ -103,7 +103,7 @@ describe('transform', () => {
   });
 
   it('should transform local spans', () => {
-    readableSpan.spanContext.isRemote = false;
+    readableSpan.spanContext().isRemote = false;
     const local = transformer(readableSpan);
     assert.deepStrictEqual(local.sameProcessAsParentSpan, {value: true});
   });
@@ -164,6 +164,7 @@ describe('transform', () => {
       context: {
         traceId: 'a4cda95b652f4a1592b449d5929fda1b',
         spanId: '3e0c63257de34c92',
+        traceFlags: api.TraceFlags.SAMPLED,
       },
     });
 
@@ -189,6 +190,7 @@ describe('transform', () => {
       context: {
         traceId: 'a4cda95b652f4a1592b449d5929fda1b',
         spanId: '3e0c63257de34c92',
+        traceFlags: api.TraceFlags.SAMPLED,
       },
       attributes: {
         testAttr: 'value',

--- a/packages/opentelemetry-cloud-trace-propagator/package-lock.json
+++ b/packages/opentelemetry-cloud-trace-propagator/package-lock.json
@@ -12,8 +12,8 @@
 				"hex2dec": "^1.0.1"
 			},
 			"devDependencies": {
-				"@opentelemetry/api": "0.18.1",
-				"@opentelemetry/core": "0.18.2",
+				"@opentelemetry/api": "0.21.0",
+				"@opentelemetry/core": "0.21.0",
 				"@types/mocha": "7.0.2",
 				"@types/node": "14.14.41",
 				"codecov": "3.8.1",
@@ -28,8 +28,8 @@
 				"node": ">=10"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^0.18.0",
-				"@opentelemetry/core": "^0.18.0"
+				"@opentelemetry/api": "^0.21.0",
+				"@opentelemetry/core": "^0.21.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -491,25 +491,37 @@
 			}
 		},
 		"node_modules/@opentelemetry/api": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.18.1.tgz",
-			"integrity": "sha512-pKNxHe3AJ5T2N5G3AlT9gx6FyF5K2FS9ZNc+FipC+f1CpVF/EY+JHTJ749dnM2kWIgZTbDJFiGMuc0FYjNSCOg==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.21.0.tgz",
+			"integrity": "sha512-Q7hHb3nidPgnBS2fi+y3K64F3EV48d9v09/6EtigIgVF43NFNhw/dboDKC7gECEkbTwuvFeLCbwKs9JaC8LDEw==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/core": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.18.2.tgz",
-			"integrity": "sha512-WG8veOEd8xZHuBaOHddzWQg5yj794lrEPAe6W1qI0YkV7pyqYXvhJdCxOU5Lyo1SWzTAjI5xrCUQ9J2WlrqzYA==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.21.0.tgz",
+			"integrity": "sha512-sZZQThBuqhCdBPgzPq4y9L4dhnpXXCCEqNsR6IUmMc/kQ8Bcw3lmI5fymLlliSt+lnTc26xJPVKZlwoQfwhThg==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/api": "^0.18.1",
+				"@opentelemetry/semantic-conventions": "0.21.0",
 				"semver": "^7.1.3"
 			},
 			"engines": {
 				"node": ">=8.5.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^0.21.0"
+			}
+		},
+		"node_modules/@opentelemetry/semantic-conventions": {
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.21.0.tgz",
+			"integrity": "sha512-qQtZJ8Q+bO/gemBELsZbz5s//tNnyc+mQD/0RHc77XhI6ZBb+tprU6KN/7l0fl5z29smmai0hcJ9UNILC/7nIw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@sindresorhus/is": {
@@ -5924,20 +5936,26 @@
 			}
 		},
 		"@opentelemetry/api": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.18.1.tgz",
-			"integrity": "sha512-pKNxHe3AJ5T2N5G3AlT9gx6FyF5K2FS9ZNc+FipC+f1CpVF/EY+JHTJ749dnM2kWIgZTbDJFiGMuc0FYjNSCOg==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.21.0.tgz",
+			"integrity": "sha512-Q7hHb3nidPgnBS2fi+y3K64F3EV48d9v09/6EtigIgVF43NFNhw/dboDKC7gECEkbTwuvFeLCbwKs9JaC8LDEw==",
 			"dev": true
 		},
 		"@opentelemetry/core": {
-			"version": "0.18.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.18.2.tgz",
-			"integrity": "sha512-WG8veOEd8xZHuBaOHddzWQg5yj794lrEPAe6W1qI0YkV7pyqYXvhJdCxOU5Lyo1SWzTAjI5xrCUQ9J2WlrqzYA==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.21.0.tgz",
+			"integrity": "sha512-sZZQThBuqhCdBPgzPq4y9L4dhnpXXCCEqNsR6IUmMc/kQ8Bcw3lmI5fymLlliSt+lnTc26xJPVKZlwoQfwhThg==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/api": "^0.18.1",
+				"@opentelemetry/semantic-conventions": "0.21.0",
 				"semver": "^7.1.3"
 			}
+		},
+		"@opentelemetry/semantic-conventions": {
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.21.0.tgz",
+			"integrity": "sha512-qQtZJ8Q+bO/gemBELsZbz5s//tNnyc+mQD/0RHc77XhI6ZBb+tprU6KN/7l0fl5z29smmai0hcJ9UNILC/7nIw==",
+			"dev": true
 		},
 		"@sindresorhus/is": {
 			"version": "0.14.0",

--- a/packages/opentelemetry-cloud-trace-propagator/package.json
+++ b/packages/opentelemetry-cloud-trace-propagator/package.json
@@ -38,8 +38,8 @@
     "registry": "https://wombat-dressing-room.appspot.com"
   },
   "devDependencies": {
-    "@opentelemetry/api": "0.18.1",
-    "@opentelemetry/core": "0.18.2",
+    "@opentelemetry/api": "0.21.0",
+    "@opentelemetry/core": "0.21.0",
     "@types/mocha": "7.0.2",
     "@types/node": "14.14.41",
     "codecov": "3.8.1",
@@ -54,7 +54,7 @@
     "hex2dec": "^1.0.1"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^0.18.0",
-    "@opentelemetry/core": "^0.18.0"
+    "@opentelemetry/api": "^0.21.0",
+    "@opentelemetry/core": "^0.21.0"
   }
 }

--- a/packages/opentelemetry-cloud-trace-propagator/src/CloudPropagator.ts
+++ b/packages/opentelemetry-cloud-trace-propagator/src/CloudPropagator.ts
@@ -16,8 +16,7 @@ import {
   TextMapPropagator,
   Context,
   TraceFlags,
-  setSpanContext,
-  getSpanContext,
+  trace,
   TextMapSetter,
   TextMapGetter,
 } from '@opentelemetry/api';
@@ -49,7 +48,7 @@ export class CloudPropagator implements TextMapPropagator {
     carrier: unknown,
     setter: TextMapSetter<unknown>
   ): void {
-    const spanContext = getSpanContext(context);
+    const spanContext = trace.getSpanContext(context);
     if (!spanContext) return;
 
     const header = `${spanContext.traceId}/${hexToDec(spanContext.spanId)};o=${
@@ -93,7 +92,7 @@ export class CloudPropagator implements TextMapPropagator {
       isRemote: true,
     };
 
-    return setSpanContext(context, spanContext);
+    return trace.setSpanContext(context, spanContext);
   }
 
   fields(): string[] {

--- a/packages/opentelemetry-cloud-trace-propagator/test/CloudPropagator.test.ts
+++ b/packages/opentelemetry-cloud-trace-propagator/test/CloudPropagator.test.ts
@@ -15,9 +15,8 @@
 import {
   defaultTextMapGetter,
   defaultTextMapSetter,
-  getSpan,
   ROOT_CONTEXT,
-  setSpanContext,
+  trace,
   SpanContext,
   TraceFlags,
 } from '@opentelemetry/api';
@@ -41,7 +40,7 @@ describe('CloudPropagator', () => {
       };
 
       cloudPropagator.inject(
-        setSpanContext(ROOT_CONTEXT, spanContext),
+        trace.setSpanContext(ROOT_CONTEXT, spanContext),
         carrier,
         defaultTextMapSetter
       );
@@ -58,7 +57,7 @@ describe('CloudPropagator', () => {
         traceFlags: TraceFlags.NONE,
       };
       cloudPropagator.inject(
-        setSpanContext(ROOT_CONTEXT, spanContext),
+        trace.setSpanContext(ROOT_CONTEXT, spanContext),
         carrier,
         defaultTextMapSetter
       );
@@ -73,9 +72,11 @@ describe('CloudPropagator', () => {
     it('should extract context of a sampled span from carrier', () => {
       carrier[X_CLOUD_TRACE_HEADER] =
         'd4cda95b652f4a1592b449d5929fda1b/7929822056569588882;o=1';
-      const extractedSpanContext = getSpan(
-        cloudPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
-      )?.context();
+      const extractedSpanContext = trace
+        .getSpan(
+          cloudPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
+        )
+        ?.spanContext();
 
       assert.deepStrictEqual(extractedSpanContext, {
         traceId: 'd4cda95b652f4a1592b449d5929fda1b',
@@ -88,9 +89,11 @@ describe('CloudPropagator', () => {
     it('should extract context of a unsampled span from carrier', () => {
       carrier[X_CLOUD_TRACE_HEADER] =
         'd4cda95b652f4a1592b449d5929fda1b/7929822056569588882;o=0';
-      const extractedSpanContext = getSpan(
-        cloudPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
-      )?.context();
+      const extractedSpanContext = trace
+        .getSpan(
+          cloudPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
+        )
+        ?.spanContext();
 
       assert.deepStrictEqual(extractedSpanContext, {
         traceId: 'd4cda95b652f4a1592b449d5929fda1b',
@@ -103,9 +106,11 @@ describe('CloudPropagator', () => {
     it('should handle trace_flags other than 0 and 1', () => {
       carrier[X_CLOUD_TRACE_HEADER] =
         'd4cda95b652f4a1592b449d5929fda1b/7929822056569588882;o=123';
-      const extractedSpanContext = getSpan(
-        cloudPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
-      )?.context();
+      const extractedSpanContext = trace
+        .getSpan(
+          cloudPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
+        )
+        ?.spanContext();
 
       assert.deepStrictEqual(extractedSpanContext, {
         traceId: 'd4cda95b652f4a1592b449d5929fda1b',
@@ -118,9 +123,11 @@ describe('CloudPropagator', () => {
     it('should handle missing trace_flags', () => {
       carrier[X_CLOUD_TRACE_HEADER] =
         'b75dc0042a82efcb6b0a194911272926/1258215';
-      const extractedSpanContext = getSpan(
-        cloudPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
-      )?.context();
+      const extractedSpanContext = trace
+        .getSpan(
+          cloudPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
+        )
+        ?.spanContext();
 
       assert.deepStrictEqual(
         extractedSpanContext!.traceId,
@@ -134,9 +141,11 @@ describe('CloudPropagator', () => {
       carrier[X_CLOUD_TRACE_HEADER] = [
         'd4cda95b652f4a1592b449d5929fda1b/7929822056569588882;o=1',
       ];
-      const extractedSpanContext = getSpan(
-        cloudPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
-      )?.context();
+      const extractedSpanContext = trace
+        .getSpan(
+          cloudPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
+        )
+        ?.spanContext();
       assert.deepStrictEqual(extractedSpanContext, {
         traceId: 'd4cda95b652f4a1592b449d5929fda1b',
         spanId: '6e0c63257de34c92',
@@ -147,9 +156,11 @@ describe('CloudPropagator', () => {
 
     it('returns undefined if x-cloud-trace-context header is missing', () => {
       assert.deepStrictEqual(
-        getSpan(
-          cloudPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
-        )?.context(),
+        trace
+          .getSpan(
+            cloudPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
+          )
+          ?.spanContext(),
         undefined
       );
     });
@@ -177,9 +188,11 @@ describe('CloudPropagator', () => {
       for (const [testName, testData] of Object.entries(testCases)) {
         carrier[X_CLOUD_TRACE_HEADER] = testData;
 
-        const extractedSpanContext = getSpan(
-          cloudPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
-        )?.context();
+        const extractedSpanContext = trace
+          .getSpan(
+            cloudPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
+          )
+          ?.spanContext();
 
         assert.deepStrictEqual(extractedSpanContext, undefined, testName);
       }

--- a/samples/trace/package-lock.json
+++ b/samples/trace/package-lock.json
@@ -9,121 +9,133 @@
 			"version": "0.9.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api": "^0.18.0",
-				"@opentelemetry/node": "^0.18.0",
-				"@opentelemetry/tracing": "^0.18.0"
+				"@opentelemetry/api": "^0.21.0",
+				"@opentelemetry/node": "^0.21.0",
+				"@opentelemetry/tracing": "^0.21.0"
 			},
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/@opentelemetry/api": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.18.0.tgz",
-			"integrity": "sha512-KczG0mtyH2UQLeFDYC+atGXfS/MfttynmHblJUsOnIgfI0Ohn0nJOgNjKwJlHk6/9Q61CBTxzSs/268TDaopVw==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.21.0.tgz",
+			"integrity": "sha512-Q7hHb3nidPgnBS2fi+y3K64F3EV48d9v09/6EtigIgVF43NFNhw/dboDKC7gECEkbTwuvFeLCbwKs9JaC8LDEw==",
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/context-async-hooks": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.18.0.tgz",
-			"integrity": "sha512-PD1aHXyniFtZIXbLuCr+KaZiufrGJPuEZ6eMZggQRi7+AC3alAfAVRz88sLmeR49pd7lRRFiKzymzVqJRMEmjw==",
-			"dependencies": {
-				"@opentelemetry/api": "^0.18.0"
-			},
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.21.0.tgz",
+			"integrity": "sha512-3XxzT7jiDLbohUy66NWsYuWFtXsMI0qMhetWVlFmmBfMPLMR+U6xWA4xhfRMb6kMEjR5XJHbyDSxYwzxrd10sg==",
 			"engines": {
 				"node": ">=8.1.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^0.21.0"
 			}
 		},
 		"node_modules/@opentelemetry/core": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.18.0.tgz",
-			"integrity": "sha512-Kg+LBIAPK70tEtpIAdZomkUmbABK+EwfnjFfvJ1rVZ8e0NApDx14Sq92RbGDIf67TK5mBgIvvY27W+ic354UZQ==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.21.0.tgz",
+			"integrity": "sha512-sZZQThBuqhCdBPgzPq4y9L4dhnpXXCCEqNsR6IUmMc/kQ8Bcw3lmI5fymLlliSt+lnTc26xJPVKZlwoQfwhThg==",
 			"dependencies": {
-				"@opentelemetry/api": "^0.18.0",
+				"@opentelemetry/semantic-conventions": "0.21.0",
 				"semver": "^7.1.3"
 			},
 			"engines": {
 				"node": ">=8.5.0"
-			}
-		},
-		"node_modules/@opentelemetry/core/node_modules/semver": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
 			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
+			"peerDependencies": {
+				"@opentelemetry/api": "^0.21.0"
 			}
 		},
 		"node_modules/@opentelemetry/node": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/node/-/node-0.18.0.tgz",
-			"integrity": "sha512-KjN6O+BvNmBwjQHKpcIRyxebrRuEMUzyS4Y13ZMH684fBMwRTju45aDz7ILCFndGECvbtl8nDY0US7+HCimpXw==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/node/-/node-0.21.0.tgz",
+			"integrity": "sha512-PCA3pFmzTMN3iIlZ6Bz2BgPe8jEIdKRK7WyjfT9qqrLrHZ/dXNmX4MIz2IKTyQtS6tGt2jayD0IpWsVFctPOIA==",
 			"dependencies": {
-				"@opentelemetry/api": "^0.18.0",
-				"@opentelemetry/context-async-hooks": "^0.18.0",
-				"@opentelemetry/core": "^0.18.0",
-				"@opentelemetry/tracing": "^0.18.0",
+				"@opentelemetry/context-async-hooks": "0.21.0",
+				"@opentelemetry/core": "0.21.0",
+				"@opentelemetry/propagator-b3": "0.21.0",
+				"@opentelemetry/propagator-jaeger": "0.21.0",
+				"@opentelemetry/tracing": "0.21.0",
 				"semver": "^7.1.3"
 			},
 			"engines": {
 				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^0.21.0"
 			}
 		},
-		"node_modules/@opentelemetry/node/node_modules/semver": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+		"node_modules/@opentelemetry/propagator-b3": {
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-0.21.0.tgz",
+			"integrity": "sha512-KXQKXa76ilzBNdwr7hze9251g0AqBmwhCPnt17UCgb+97DFcOyEy5Rc7nnjZNxNGYYqUbk8116MK9hMZO2icGw==",
 			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@opentelemetry/resources": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.18.0.tgz",
-			"integrity": "sha512-Mko4HpoI5cCYplhSyiCuMFi0QEG1Nw/YwHFyAK+A67r+sgmo1wVpM6Pengb+XlxJrrO8WgmLsDS3RHqoMWhWNQ==",
-			"dependencies": {
-				"@opentelemetry/api": "^0.18.0",
-				"@opentelemetry/core": "^0.18.0"
+				"@opentelemetry/core": "0.21.0"
 			},
 			"engines": {
 				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^0.21.0"
+			}
+		},
+		"node_modules/@opentelemetry/propagator-jaeger": {
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-0.21.0.tgz",
+			"integrity": "sha512-H0TaYBvDi4stz19UJNPFR1IRikQYjoKYuV6tZV4V5NnPAFTjBhvj/Heb0fNDUWK5G1tVB5NPrEsNSZjjdfvjLw==",
+			"dependencies": {
+				"@opentelemetry/core": "0.21.0"
+			},
+			"engines": {
+				"node": ">=8.5.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^0.21.0"
+			}
+		},
+		"node_modules/@opentelemetry/resources": {
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.21.0.tgz",
+			"integrity": "sha512-xQUL2/2npP/isH8sbOSdynIRWmlM6p02L9Ex8x/BhUuSkGrMoxO2ezLPPYnfYam1py6ubaz8m1C54O2IRCmgQQ==",
+			"dependencies": {
+				"@opentelemetry/core": "0.21.0",
+				"@opentelemetry/semantic-conventions": "0.21.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^0.21.0"
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.18.0.tgz",
-			"integrity": "sha512-02Wi/zFq+RWfY4llRicMashGhyZvUtMfXu9UlfXMJiDbGOgkdua4AeOCv9lDqv1GIz11xr5qS4tFjLp7WnlU+Q==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.21.0.tgz",
+			"integrity": "sha512-qQtZJ8Q+bO/gemBELsZbz5s//tNnyc+mQD/0RHc77XhI6ZBb+tprU6KN/7l0fl5z29smmai0hcJ9UNILC/7nIw==",
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/tracing": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.18.0.tgz",
-			"integrity": "sha512-k7UAebuHBLPafS8rnkpZqNuM8nfwOg6OCmppekCMxdQzkuZS1attgelqyEIlX6NYh46DndyZ7BxBkiXF4S0Xwg==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.21.0.tgz",
+			"integrity": "sha512-6+2pfFpu7Yo2DwmBK9sHDUSIL7UshcEMwDF6+LghGK68ILRaEMqqBPgKarjhFH9ERgJB9GOkJ2snK96qIzMZNA==",
 			"dependencies": {
-				"@opentelemetry/api": "^0.18.0",
-				"@opentelemetry/core": "^0.18.0",
-				"@opentelemetry/resources": "^0.18.0",
-				"@opentelemetry/semantic-conventions": "^0.18.0",
+				"@opentelemetry/core": "0.21.0",
+				"@opentelemetry/resources": "0.21.0",
+				"@opentelemetry/semantic-conventions": "0.21.0",
 				"lodash.merge": "^4.6.2"
 			},
 			"engines": {
 				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^0.21.0"
 			}
 		},
 		"node_modules/lodash.merge": {
@@ -142,6 +154,20 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/semver": {
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -150,82 +176,76 @@
 	},
 	"dependencies": {
 		"@opentelemetry/api": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.18.0.tgz",
-			"integrity": "sha512-KczG0mtyH2UQLeFDYC+atGXfS/MfttynmHblJUsOnIgfI0Ohn0nJOgNjKwJlHk6/9Q61CBTxzSs/268TDaopVw=="
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.21.0.tgz",
+			"integrity": "sha512-Q7hHb3nidPgnBS2fi+y3K64F3EV48d9v09/6EtigIgVF43NFNhw/dboDKC7gECEkbTwuvFeLCbwKs9JaC8LDEw=="
 		},
 		"@opentelemetry/context-async-hooks": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.18.0.tgz",
-			"integrity": "sha512-PD1aHXyniFtZIXbLuCr+KaZiufrGJPuEZ6eMZggQRi7+AC3alAfAVRz88sLmeR49pd7lRRFiKzymzVqJRMEmjw==",
-			"requires": {
-				"@opentelemetry/api": "^0.18.0"
-			}
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.21.0.tgz",
+			"integrity": "sha512-3XxzT7jiDLbohUy66NWsYuWFtXsMI0qMhetWVlFmmBfMPLMR+U6xWA4xhfRMb6kMEjR5XJHbyDSxYwzxrd10sg==",
+			"requires": {}
 		},
 		"@opentelemetry/core": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.18.0.tgz",
-			"integrity": "sha512-Kg+LBIAPK70tEtpIAdZomkUmbABK+EwfnjFfvJ1rVZ8e0NApDx14Sq92RbGDIf67TK5mBgIvvY27W+ic354UZQ==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.21.0.tgz",
+			"integrity": "sha512-sZZQThBuqhCdBPgzPq4y9L4dhnpXXCCEqNsR6IUmMc/kQ8Bcw3lmI5fymLlliSt+lnTc26xJPVKZlwoQfwhThg==",
 			"requires": {
-				"@opentelemetry/api": "^0.18.0",
+				"@opentelemetry/semantic-conventions": "0.21.0",
 				"semver": "^7.1.3"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
 			}
 		},
 		"@opentelemetry/node": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/node/-/node-0.18.0.tgz",
-			"integrity": "sha512-KjN6O+BvNmBwjQHKpcIRyxebrRuEMUzyS4Y13ZMH684fBMwRTju45aDz7ILCFndGECvbtl8nDY0US7+HCimpXw==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/node/-/node-0.21.0.tgz",
+			"integrity": "sha512-PCA3pFmzTMN3iIlZ6Bz2BgPe8jEIdKRK7WyjfT9qqrLrHZ/dXNmX4MIz2IKTyQtS6tGt2jayD0IpWsVFctPOIA==",
 			"requires": {
-				"@opentelemetry/api": "^0.18.0",
-				"@opentelemetry/context-async-hooks": "^0.18.0",
-				"@opentelemetry/core": "^0.18.0",
-				"@opentelemetry/tracing": "^0.18.0",
+				"@opentelemetry/context-async-hooks": "0.21.0",
+				"@opentelemetry/core": "0.21.0",
+				"@opentelemetry/propagator-b3": "0.21.0",
+				"@opentelemetry/propagator-jaeger": "0.21.0",
+				"@opentelemetry/tracing": "0.21.0",
 				"semver": "^7.1.3"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
+			}
+		},
+		"@opentelemetry/propagator-b3": {
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-0.21.0.tgz",
+			"integrity": "sha512-KXQKXa76ilzBNdwr7hze9251g0AqBmwhCPnt17UCgb+97DFcOyEy5Rc7nnjZNxNGYYqUbk8116MK9hMZO2icGw==",
+			"requires": {
+				"@opentelemetry/core": "0.21.0"
+			}
+		},
+		"@opentelemetry/propagator-jaeger": {
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-0.21.0.tgz",
+			"integrity": "sha512-H0TaYBvDi4stz19UJNPFR1IRikQYjoKYuV6tZV4V5NnPAFTjBhvj/Heb0fNDUWK5G1tVB5NPrEsNSZjjdfvjLw==",
+			"requires": {
+				"@opentelemetry/core": "0.21.0"
 			}
 		},
 		"@opentelemetry/resources": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.18.0.tgz",
-			"integrity": "sha512-Mko4HpoI5cCYplhSyiCuMFi0QEG1Nw/YwHFyAK+A67r+sgmo1wVpM6Pengb+XlxJrrO8WgmLsDS3RHqoMWhWNQ==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.21.0.tgz",
+			"integrity": "sha512-xQUL2/2npP/isH8sbOSdynIRWmlM6p02L9Ex8x/BhUuSkGrMoxO2ezLPPYnfYam1py6ubaz8m1C54O2IRCmgQQ==",
 			"requires": {
-				"@opentelemetry/api": "^0.18.0",
-				"@opentelemetry/core": "^0.18.0"
+				"@opentelemetry/core": "0.21.0",
+				"@opentelemetry/semantic-conventions": "0.21.0"
 			}
 		},
 		"@opentelemetry/semantic-conventions": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.18.0.tgz",
-			"integrity": "sha512-02Wi/zFq+RWfY4llRicMashGhyZvUtMfXu9UlfXMJiDbGOgkdua4AeOCv9lDqv1GIz11xr5qS4tFjLp7WnlU+Q=="
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.21.0.tgz",
+			"integrity": "sha512-qQtZJ8Q+bO/gemBELsZbz5s//tNnyc+mQD/0RHc77XhI6ZBb+tprU6KN/7l0fl5z29smmai0hcJ9UNILC/7nIw=="
 		},
 		"@opentelemetry/tracing": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.18.0.tgz",
-			"integrity": "sha512-k7UAebuHBLPafS8rnkpZqNuM8nfwOg6OCmppekCMxdQzkuZS1attgelqyEIlX6NYh46DndyZ7BxBkiXF4S0Xwg==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.21.0.tgz",
+			"integrity": "sha512-6+2pfFpu7Yo2DwmBK9sHDUSIL7UshcEMwDF6+LghGK68ILRaEMqqBPgKarjhFH9ERgJB9GOkJ2snK96qIzMZNA==",
 			"requires": {
-				"@opentelemetry/api": "^0.18.0",
-				"@opentelemetry/core": "^0.18.0",
-				"@opentelemetry/resources": "^0.18.0",
-				"@opentelemetry/semantic-conventions": "^0.18.0",
+				"@opentelemetry/core": "0.21.0",
+				"@opentelemetry/resources": "0.21.0",
+				"@opentelemetry/semantic-conventions": "0.21.0",
 				"lodash.merge": "^4.6.2"
 			}
 		},
@@ -240,6 +260,14 @@
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"requires": {
 				"yallist": "^4.0.0"
+			}
+		},
+		"semver": {
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"requires": {
+				"lru-cache": "^6.0.0"
 			}
 		},
 		"yallist": {

--- a/samples/trace/package.json
+++ b/samples/trace/package.json
@@ -13,8 +13,8 @@
   "repository": "GoogleCloudPlatform/opentelemetry-operations-js",
   "dependencies": {
     "@google-cloud/opentelemetry-cloud-trace-exporter": "^0.9.0",
-    "@opentelemetry/api": "^0.18.0",
-    "@opentelemetry/node": "^0.18.0",
-    "@opentelemetry/tracing": "^0.18.0"
+    "@opentelemetry/api": "^0.21.0",
+    "@opentelemetry/node": "^0.21.0",
+    "@opentelemetry/tracing": "^0.21.0"
   }
 }


### PR DESCRIPTION
Fixes #273, fixes #252

0.21.0 is the newest version of all OTel JS packages. Fixed a few renames and type breakages. Use new semantic-convention package for applicable constants.