### PR TITLE
chore: update ci runs to use only current node versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 15]
+        node: [10, 12, 14, 16]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
- Node 15 (non LTS) is no longer supported and 16 is the current release https://nodejs.org/en/about/releases/
- I am leaving node 10 for now as most things still support it.
- Ignore cloud build CI failures for now