### PR TITLE
chore: e2e test runner version and adjust timeouts

### DIFF
--- a/cloudbuild-e2e-gce.yaml
+++ b/cloudbuild-e2e-gce.yaml
@@ -30,8 +30,10 @@ steps:
     args:
       - gce
       - --image=$_TEST_SERVER_IMAGE
+      - --health-check-timeout=5m
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
+timeout: 20m
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/opentelemetry-ops-e2e/opentelemetry-operations-e2e-testing:0.5.24
+  _TEST_RUNNER_IMAGE: gcr.io/opentelemetry-ops-e2e/opentelemetry-operations-e2e-testing:0.6.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gke.yaml
+++ b/cloudbuild-e2e-gke.yaml
@@ -31,6 +31,7 @@ steps:
       - --image=$_TEST_SERVER_IMAGE
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
+timeout: 20m
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/opentelemetry-ops-e2e/opentelemetry-operations-e2e-testing:0.5.24
+  _TEST_RUNNER_IMAGE: gcr.io/opentelemetry-ops-e2e/opentelemetry-operations-e2e-testing:0.6.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-local.yaml
+++ b/cloudbuild-e2e-local.yaml
@@ -33,6 +33,7 @@ steps:
       - --network=cloudbuild
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
+timeout: 20m
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/opentelemetry-ops-e2e/opentelemetry-operations-e2e-testing:0.5.24
+  _TEST_RUNNER_IMAGE: gcr.io/opentelemetry-ops-e2e/opentelemetry-operations-e2e-testing:0.6.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}


### PR DESCRIPTION
- GCE container images are taking a little longer than previously to come up, so adjust its health check timeout to be longer
- Made the overall timeout for the test runs 20 minutes.
     * There are timeouts in the actual test runner code which should stop the test before this longer timeout
     * Cloud Build kills a test immediately when it times out, which is bad because we don't get to teardown the resources we created
- The `0.6.0` version has `--health-check-timeout` instead of `--healthchecktimeout`