### PR TITLE
chore: 0.10.0 release proposal

### DIFF
--- a/e2e-test-server/package-lock.json
+++ b/e2e-test-server/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@google-cloud/e2e-test-server",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@google-cloud/e2e-test-server",
-			"version": "0.9.0",
+			"version": "0.10.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@google-cloud/pubsub": "^2.12.0",

--- a/e2e-test-server/package.json
+++ b/e2e-test-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/e2e-test-server",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Instrumented test server used only for e2e testing (private).",
   "private": true,
   "main": "build/src/index.js",
@@ -31,7 +31,7 @@
     "typescript": "4.3.4"
   },
   "dependencies": {
-    "@google-cloud/opentelemetry-cloud-trace-exporter": "^0.9.0",
+    "@google-cloud/opentelemetry-cloud-trace-exporter": "^0.10.0",
     "@google-cloud/pubsub": "^2.12.0",
     "@grpc/grpc-js": "^1.3.2",
     "@opentelemetry/api": "^1.0.0",

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "samples/*",
     "e2e-test-server"
   ],
-  "version": "0.9.0"
+  "version": "0.10.0"
 }

--- a/packages/opentelemetry-cloud-monitoring-exporter/package-lock.json
+++ b/packages/opentelemetry-cloud-monitoring-exporter/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@google-cloud/opentelemetry-cloud-monitoring-exporter",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@google-cloud/opentelemetry-cloud-monitoring-exporter",
-			"version": "0.9.0",
+			"version": "0.10.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^0.22.0",

--- a/packages/opentelemetry-cloud-monitoring-exporter/package.json
+++ b/packages/opentelemetry-cloud-monitoring-exporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/opentelemetry-cloud-monitoring-exporter",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "OpenTelemetry Google Cloud Monitoring Exporter allows the user to send collected metrics to Google Cloud Monitoring.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -58,7 +58,7 @@
     "typescript": "4.3.4"
   },
   "dependencies": {
-    "@google-cloud/opentelemetry-resource-util": "^0.9.0",
+    "@google-cloud/opentelemetry-resource-util": "^0.10.0",
     "@opentelemetry/semantic-conventions": "^0.22.0",
     "google-auth-library": "^7.0.0",
     "googleapis": "^76.0.0"

--- a/packages/opentelemetry-cloud-trace-exporter/package-lock.json
+++ b/packages/opentelemetry-cloud-trace-exporter/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@google-cloud/opentelemetry-cloud-trace-exporter",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@google-cloud/opentelemetry-cloud-trace-exporter",
-			"version": "0.9.0",
+			"version": "0.10.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.1.8",

--- a/packages/opentelemetry-cloud-trace-exporter/package.json
+++ b/packages/opentelemetry-cloud-trace-exporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/opentelemetry-cloud-trace-exporter",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "OpenTelemetry Google Cloud Trace Exporter allows the user to send collected traces to Google Cloud Trace.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -56,7 +56,7 @@
     "typescript": "4.3.4"
   },
   "dependencies": {
-    "@google-cloud/opentelemetry-resource-util": "^0.9.0",
+    "@google-cloud/opentelemetry-resource-util": "^0.10.0",
     "@grpc/grpc-js": "^1.1.8",
     "@grpc/proto-loader": "^0.6.0",
     "google-auth-library": "^7.0.0",

--- a/packages/opentelemetry-cloud-trace-exporter/src/version.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/version.ts
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export const VERSION = '0.9.0';
+export const VERSION = '0.10.0';

--- a/packages/opentelemetry-cloud-trace-propagator/package-lock.json
+++ b/packages/opentelemetry-cloud-trace-propagator/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@google-cloud/opentelemetry-cloud-trace-propagator",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@google-cloud/opentelemetry-cloud-trace-propagator",
-			"version": "0.9.0",
+			"version": "0.10.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"hex2dec": "^1.0.1"

--- a/packages/opentelemetry-cloud-trace-propagator/package.json
+++ b/packages/opentelemetry-cloud-trace-propagator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/opentelemetry-cloud-trace-propagator",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "OpenTelemetry propagation package for Google Cloud Trace format",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-resource-util/package-lock.json
+++ b/packages/opentelemetry-resource-util/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@google-cloud/opentelemetry-resource-util",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@google-cloud/opentelemetry-resource-util",
-			"version": "0.9.0",
+			"version": "0.10.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@opentelemetry/api": "1.0.0",

--- a/packages/opentelemetry-resource-util/package.json
+++ b/packages/opentelemetry-resource-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@google-cloud/opentelemetry-resource-util",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Resource util used by other @google-cloud/opentelemetry* packages",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/samples/trace/package-lock.json
+++ b/samples/trace/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "nodejs-example-google-cloud-trace",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "nodejs-example-google-cloud-trace",
-			"version": "0.9.0",
+			"version": "0.10.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.0.0",

--- a/samples/trace/package.json
+++ b/samples/trace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-example-google-cloud-trace",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "license": "Apache-2.0",
   "author": "Google Inc.",
@@ -12,7 +12,7 @@
   },
   "repository": "GoogleCloudPlatform/opentelemetry-operations-js",
   "dependencies": {
-    "@google-cloud/opentelemetry-cloud-trace-exporter": "^0.9.0",
+    "@google-cloud/opentelemetry-cloud-trace-exporter": "^0.10.0",
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/node": "^0.22.0",
     "@opentelemetry/tracing": "^0.22.0"


### PR DESCRIPTION
Release proposal https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/releases/edit/untagged-f49888a55d0fade43547

# [0.10.0](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/compare/v0.9.0...v0.10.0) (2021-06-21)


### Bug Fixes

* uncaught rejected promise error in MetricExporter's export method ([#258](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/258)) ([541d3f0](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/commit/541d3f002888eb19e836e0be3961917a356fcc80))
* **deps:** update all non-major dependencies ([#255](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/255)) ([1f6423c](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/commit/1f6423ccc15b257b1674cbc6143eaf0ada2c45a2))
* **deps:** update dependency googleapis to v68 ([#249](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/249)) ([c513280](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/commit/c51328076326124f129b547ca9a8980cd1261c94))
* **deps:** update dependency googleapis to v70 ([#253](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/253)) ([103e0a4](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/commit/103e0a4426560bd9a8cc932af2f03a889f2bd1fe))
* **deps:** update dependency googleapis to v71 ([#256](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/256)) ([0ee7172](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/commit/0ee7172ff6d874cc88eab293e0010c25e4f89487))
* **deps:** update dependency googleapis to v72 ([#262](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/262)) ([2f9011f](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/commit/2f9011f66e5991604e41b7c657eb0e89a32e1d45))
* **deps:** update dependency googleapis to v73 ([#263](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/263)) ([de795d6](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/commit/de795d6580b5f92cc80ec9f3f75bbd50253d1487))
* **deps:** update dependency googleapis to v75 ([#272](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/272)) ([2023ab5](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/commit/2023ab5ef8ab992c41eac5b71c91d7d5204d4ac6))
* **deps:** update dependency googleapis to v76 ([#277](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/277)) ([40450b2](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/commit/40450b26cf7797ee6034eab184dd49eb20fb94a6))


### Features

* e2e test server initial implementation ([#278](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/278)) ([e2460c6](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/commit/e2460c6446a53b628508512b00c5c9c063a10bd7))
* map OTel resource to monitored resource for g.co/r attributes ([#285](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/285)) ([b15359e](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/commit/b15359e34104c4b7c12a0128a7bab18f92e8ad9f))
* separate resource mapping utils into separate package ([#282](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/282)) ([9e46aa3](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/commit/9e46aa302cb2d95b9297c27af99cd29ba9e5d9ef))
* stop adding project id to span attributes ([#268](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/268)) ([4653bb4](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/commit/4653bb4b8d825ec7bf60cccc8adc9d6b61fc70df))


### BREAKING CHANGES

* no longer sends all resource labels along with each
commit, just the monitored resource g.co/r labels. This is in line with
what our other exporters do.
* spans will no longer have project id attribute