### PR TITLE
feat(trace-exporter)!: send span kind to cloud trace

### DIFF
--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -24,9 +24,10 @@ import {
   Link,
   LinkType,
   Span,
+  SpanKind,
+  Status,
   Timestamp,
   TruncatableString,
-  Status,
 } from './types';
 import {mapOtelResourceToMonitoredResource} from '@google-cloud/opentelemetry-resource-util';
 import {VERSION} from './version';
@@ -59,6 +60,7 @@ export function getReadableSpanTransformer(
       name: `projects/${projectId}/traces/${span.spanContext().traceId}/spans/${
         span.spanContext().spanId
       }`,
+      spanKind: transformKind(span.kind),
       spanId: span.spanContext().spanId,
       sameProcessAsParentSpan: {value: !span.spanContext().isRemote},
       status: transformStatus(span.status),
@@ -93,6 +95,26 @@ function transformStatus(status: ot.SpanStatus): Status | undefined {
       exhaust(status.code);
       // TODO: log failed mapping
       return {code: Code.UNKNOWN, message: status.message};
+    }
+  }
+}
+
+function transformKind(kind: ot.SpanKind): SpanKind | undefined {
+  switch (kind) {
+    case ot.SpanKind.INTERNAL:
+      return SpanKind.INTERNAL;
+    case ot.SpanKind.SERVER:
+      return SpanKind.SERVER;
+    case ot.SpanKind.CLIENT:
+      return SpanKind.CLIENT;
+    case ot.SpanKind.PRODUCER:
+      return SpanKind.PRODUCER;
+    case ot.SpanKind.CONSUMER:
+      return SpanKind.CONSUMER;
+    default: {
+      exhaust(kind);
+      // TODO: log failed mapping
+      return SpanKind.SPAN_KIND_UNSPECIFIED;
     }
   }
 }

--- a/packages/opentelemetry-cloud-trace-exporter/src/types.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/types.ts
@@ -14,6 +14,8 @@
 
 import {Metadata} from '@grpc/grpc-js';
 
+// extends cloudtrace_v2.Schema$Span
+
 export interface Span {
   name?: string;
   spanId?: string;
@@ -30,6 +32,7 @@ export interface Span {
   status?: Status;
   sameProcessAsParentSpan?: BoolValue;
   childSpanCount?: number;
+  spanKind?: SpanKind;
 }
 
 export interface Timestamp {
@@ -165,4 +168,36 @@ export enum Code {
   // These are the only two we care about mapping to
   OK = 0,
   UNKNOWN = 2,
+}
+
+/**
+ * See https://github.com/googleapis/googleapis/blob/master/google/devtools/cloudtrace/v2/trace.proto#L182
+ */
+export enum SpanKind {
+  // Unspecified. Do NOT use as default.
+  // Implementations MAY assume SpanKind.INTERNAL to be default.
+  SPAN_KIND_UNSPECIFIED = 0,
+
+  // Indicates that the span is used internally. Default value.
+  INTERNAL = 1,
+
+  // Indicates that the span covers server-side handling of an RPC or other
+  // remote network request.
+  SERVER = 2,
+
+  // Indicates that the span covers the client-side wrapper around an RPC or
+  // other remote request.
+  CLIENT = 3,
+
+  // Indicates that the span describes producer sending a message to a broker.
+  // Unlike client and  server, there is no direct critical path latency
+  // relationship between producer and consumer spans (e.g. publishing a
+  // message to a pubsub service).
+  PRODUCER = 4,
+
+  // Indicates that the span describes consumer receiving a message from a
+  // broker. Unlike client and  server, there is no direct critical path
+  // latency relationship between producer and consumer spans (e.g. receiving
+  // a message from a pubsub service subscription).
+  CONSUMER = 5,
 }

--- a/packages/opentelemetry-cloud-trace-exporter/src/types.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/types.ts
@@ -14,8 +14,6 @@
 
 import {Metadata} from '@grpc/grpc-js';
 
-// extends cloudtrace_v2.Schema$Span
-
 export interface Span {
   name?: string;
   spanId?: string;
@@ -171,7 +169,7 @@ export enum Code {
 }
 
 /**
- * See https://github.com/googleapis/googleapis/blob/master/google/devtools/cloudtrace/v2/trace.proto#L182
+ * See https://github.com/googleapis/googleapis/blob/8cd4d12c0a02872469176659603451d84c0fbee7/google/devtools/cloudtrace/v2/trace.proto#L182
  */
 export enum SpanKind {
   // Unspecified. Do NOT use as default.

--- a/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
@@ -17,7 +17,7 @@ import {Resource} from '@opentelemetry/resources';
 import type {ReadableSpan} from '@opentelemetry/tracing';
 import * as assert from 'assert';
 import {getReadableSpanTransformer} from '../src/transform';
-import {LinkType, Span, Code, Status} from '../src/types';
+import {LinkType, Span, Code, Status, SpanKind} from '../src/types';
 import {VERSION} from '../src/version';
 
 describe('transform', () => {
@@ -77,6 +77,7 @@ describe('transform', () => {
       name:
         'projects/project-id/traces/d4cda95b652f4a1592b449d5929fda1b/spans/6e0c63257de34c92',
       spanId: '6e0c63257de34c92',
+      spanKind: SpanKind.CLIENT,
       status: {code: Code.OK},
       timeEvents: {timeEvent: []},
       sameProcessAsParentSpan: {value: false},
@@ -348,5 +349,53 @@ describe('transform', () => {
       },
       droppedAttributesCount: 0,
     });
+  });
+
+  it('should transform span kinds', () => {
+    assert.strictEqual(
+      transformer({
+        ...readableSpan,
+        kind: api.SpanKind.INTERNAL,
+      }).spanKind,
+      SpanKind.INTERNAL
+    );
+    assert.strictEqual(
+      transformer({
+        ...readableSpan,
+        kind: api.SpanKind.SERVER,
+      }).spanKind,
+      SpanKind.SERVER
+    );
+    assert.strictEqual(
+      transformer({
+        ...readableSpan,
+        kind: api.SpanKind.CLIENT,
+      }).spanKind,
+      SpanKind.CLIENT
+    );
+    assert.strictEqual(
+      transformer({
+        ...readableSpan,
+        kind: api.SpanKind.PRODUCER,
+      }).spanKind,
+      SpanKind.PRODUCER
+    );
+    assert.strictEqual(
+      transformer({
+        ...readableSpan,
+        kind: api.SpanKind.CONSUMER,
+      }).spanKind,
+      SpanKind.CONSUMER
+    );
+  });
+
+  it('should transform span kind of unknown future value', () => {
+    assert.strictEqual(
+      transformer({
+        ...readableSpan,
+        kind: 16,
+      }).spanKind,
+      SpanKind.SPAN_KIND_UNSPECIFIED
+    );
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: add span kind is now sent with traces.