### PR TITLE
chore: configure renovate to make separate PR for typescript

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,11 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "labels": ["dependencies"]
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["typescript"],
+      "groupName": "typescript"
+    }
+  ]
 }


### PR DESCRIPTION
Typescript version upgrades can break the build. This forces renovate to make a separate PR for Typescript upgrades to separate out breakages. This should fix the build on https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/pull/319 