### PR TITLE
fix!: rename SDK packages that were changed upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Add the exporter to your existing OpenTelemetry tracer provider (`NodeTracerProv
 
 ```js
 const { TraceExporter } = require('@google-cloud/opentelemetry-cloud-trace-exporter');
-const { NodeTracerProvider } = require('@opentelemetry/node');
-const { BatchSpanProcessor } = require('@opentelemetry/tracing');
+const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
+const { BatchSpanProcessor } = require('@opentelemetry/sdk-trace-base');
 
 
 // Enable OpenTelemetry exporters to export traces to Google Cloud Trace.

--- a/e2e-test-server/package-lock.json
+++ b/e2e-test-server/package-lock.json
@@ -12,10 +12,10 @@
 				"@google-cloud/pubsub": "^2.12.0",
 				"@grpc/grpc-js": "^1.3.2",
 				"@opentelemetry/api": "^1.0.0",
-				"@opentelemetry/context-async-hooks": "^0.24.0",
-				"@opentelemetry/core": "^0.24.0",
-				"@opentelemetry/resources": "^0.24.0",
-				"@opentelemetry/tracing": "^0.24.0",
+				"@opentelemetry/context-async-hooks": "^0.25.0",
+				"@opentelemetry/core": "^0.25.0",
+				"@opentelemetry/resources": "^0.25.0",
+				"@opentelemetry/sdk-trace-base": "^0.25.0",
 				"winston": "^3.3.3"
 			},
 			"devDependencies": {
@@ -301,66 +301,91 @@
 			}
 		},
 		"node_modules/@opentelemetry/api": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.1.tgz",
-			"integrity": "sha512-H5Djcc2txGAINgf3TNaq4yFofYSIK3722PM89S/3R8FuI/eqi1UscajlXk7EBkG9s2pxss/q6SHlpturaavXaw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.3.tgz",
+			"integrity": "sha512-puWxACExDe9nxbBB3lOymQFrLYml2dVOrd7USiVRnSbgXE+KwBu+HxFvxrzfqsiSda9IWsXJG1ef7C1O2/GmKQ==",
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/context-async-hooks": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.24.0.tgz",
-			"integrity": "sha512-Db8AgMByBEFKLJGSUBlNq4Un/Tqzj5W0hTxx3hIic8DvBwqbvUvkMGuiQYLKE2Ay21cLYMT01xK4TEKz0OxADw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.25.0.tgz",
+			"integrity": "sha512-XNjlBalbN82qCfkgPpof6g3oU/LZoyoGGrluA+cy4AKWjJ9FdEZqKwX2p2WHxEuWm8TrHh5HxqEXH5OH2o/5tw==",
 			"engines": {
 				"node": ">=8.1.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.25.0.tgz",
+			"integrity": "sha512-8OTWF4vfCENU112XB5ElLqf0eq/FhsY0SBvvY65vB3+fbZ2Oi+CPsRASrUZWGtC9MJ5rK2lBlY+/jI4a/NPPBg==",
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
+				"@opentelemetry/semantic-conventions": "0.25.0",
+				"semver": "^7.3.5"
 			},
 			"engines": {
 				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+			"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg==",
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/resources": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-			"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.25.0.tgz",
+			"integrity": "sha512-O46u53vDBlxCML8O9dIjsRcCC2VT5ri1upwhp02ITobgJ16aVD/iScCo1lPl/x2E7yq9uwzMINENiiYZRFb6XA==",
 			"dependencies": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.25.0"
 			},
 			"engines": {
 				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+			"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg==",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-base": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-0.25.0.tgz",
+			"integrity": "sha512-TInkLSF/ThM3GNVM+9tgnCVjyNLnRxvAkG585Fhu0HNwaEtCTUwI0r7AvMRIREOreeRWttBG6kvT0LOKdo8yjw==",
+			"dependencies": {
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/resources": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.25.0",
+				"lodash.merge": "^4.6.2"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.0.2"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+			"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg==",
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -369,31 +394,6 @@
 			"version": "0.18.2",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.18.2.tgz",
 			"integrity": "sha512-+0P+PrP9qSFVaayNdek4P1OAGE+PEl2SsufuHDRmUpOY25Wzjo7Atyar56Trjc32jkNy4lID6ZFT6BahsR9P9A==",
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/@opentelemetry/tracing": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.24.0.tgz",
-			"integrity": "sha512-sTLEs1SIon3xV8vLe53PzfbU0FahoxL9NPY/CYvA1mwGbMu4zHkHAjqy1Tc8JmqRrfa+XrHkmzeSM4hrvloBaA==",
-			"dependencies": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/resources": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"lodash.merge": "^4.6.2"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
-			}
-		},
-		"node_modules/@opentelemetry/tracing/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -4648,45 +4648,63 @@
 			}
 		},
 		"@opentelemetry/api": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.1.tgz",
-			"integrity": "sha512-H5Djcc2txGAINgf3TNaq4yFofYSIK3722PM89S/3R8FuI/eqi1UscajlXk7EBkG9s2pxss/q6SHlpturaavXaw=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.3.tgz",
+			"integrity": "sha512-puWxACExDe9nxbBB3lOymQFrLYml2dVOrd7USiVRnSbgXE+KwBu+HxFvxrzfqsiSda9IWsXJG1ef7C1O2/GmKQ=="
 		},
 		"@opentelemetry/context-async-hooks": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.24.0.tgz",
-			"integrity": "sha512-Db8AgMByBEFKLJGSUBlNq4Un/Tqzj5W0hTxx3hIic8DvBwqbvUvkMGuiQYLKE2Ay21cLYMT01xK4TEKz0OxADw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.25.0.tgz",
+			"integrity": "sha512-XNjlBalbN82qCfkgPpof6g3oU/LZoyoGGrluA+cy4AKWjJ9FdEZqKwX2p2WHxEuWm8TrHh5HxqEXH5OH2o/5tw==",
 			"requires": {}
 		},
 		"@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.25.0.tgz",
+			"integrity": "sha512-8OTWF4vfCENU112XB5ElLqf0eq/FhsY0SBvvY65vB3+fbZ2Oi+CPsRASrUZWGtC9MJ5rK2lBlY+/jI4a/NPPBg==",
 			"requires": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
+				"@opentelemetry/semantic-conventions": "0.25.0",
+				"semver": "^7.3.5"
 			},
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-					"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA=="
+					"version": "0.25.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+					"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg=="
 				}
 			}
 		},
 		"@opentelemetry/resources": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-			"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.25.0.tgz",
+			"integrity": "sha512-O46u53vDBlxCML8O9dIjsRcCC2VT5ri1upwhp02ITobgJ16aVD/iScCo1lPl/x2E7yq9uwzMINENiiYZRFb6XA==",
 			"requires": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.25.0"
 			},
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-					"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA=="
+					"version": "0.25.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+					"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg=="
+				}
+			}
+		},
+		"@opentelemetry/sdk-trace-base": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-0.25.0.tgz",
+			"integrity": "sha512-TInkLSF/ThM3GNVM+9tgnCVjyNLnRxvAkG585Fhu0HNwaEtCTUwI0r7AvMRIREOreeRWttBG6kvT0LOKdo8yjw==",
+			"requires": {
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/resources": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.25.0",
+				"lodash.merge": "^4.6.2"
+			},
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": {
+					"version": "0.25.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+					"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg=="
 				}
 			}
 		},
@@ -4694,24 +4712,6 @@
 			"version": "0.18.2",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.18.2.tgz",
 			"integrity": "sha512-+0P+PrP9qSFVaayNdek4P1OAGE+PEl2SsufuHDRmUpOY25Wzjo7Atyar56Trjc32jkNy4lID6ZFT6BahsR9P9A=="
-		},
-		"@opentelemetry/tracing": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.24.0.tgz",
-			"integrity": "sha512-sTLEs1SIon3xV8vLe53PzfbU0FahoxL9NPY/CYvA1mwGbMu4zHkHAjqy1Tc8JmqRrfa+XrHkmzeSM4hrvloBaA==",
-			"requires": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/resources": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"lodash.merge": "^4.6.2"
-			},
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-					"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA=="
-				}
-			}
 		},
 		"@protobufjs/aspromise": {
 			"version": "1.1.2",

--- a/e2e-test-server/package.json
+++ b/e2e-test-server/package.json
@@ -35,10 +35,10 @@
     "@google-cloud/pubsub": "^2.12.0",
     "@grpc/grpc-js": "^1.3.2",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "^0.24.0",
-    "@opentelemetry/core": "^0.24.0",
-    "@opentelemetry/resources": "^0.24.0",
-    "@opentelemetry/tracing": "^0.24.0",
+    "@opentelemetry/context-async-hooks": "^0.25.0",
+    "@opentelemetry/core": "^0.25.0",
+    "@opentelemetry/resources": "^0.25.0",
+    "@opentelemetry/sdk-trace-base": "^0.25.0",
     "winston": "^3.3.3"
   }
 }

--- a/e2e-test-server/src/scenarios.ts
+++ b/e2e-test-server/src/scenarios.ts
@@ -17,7 +17,7 @@ import {
   Tracer,
   BasicTracerProvider,
   BatchSpanProcessor,
-} from '@opentelemetry/tracing';
+} from '@opentelemetry/sdk-trace-base';
 import {AlwaysOnSampler} from '@opentelemetry/core';
 import {Resource} from '@opentelemetry/resources';
 import {TraceExporter} from '@google-cloud/opentelemetry-cloud-trace-exporter';

--- a/packages/opentelemetry-cloud-monitoring-exporter/README.md
+++ b/packages/opentelemetry-cloud-monitoring-exporter/README.md
@@ -9,14 +9,14 @@ OpenTelemetry Google Cloud Monitoring Exporter allows the user to send collected
 ## Installation
 
 ```bash
-npm install --save @opentelemetry/metrics
+npm install --save @opentelemetry/sdk-metrics-base
 npm install --save @google-cloud/opentelemetry-cloud-monitoring-exporter
 ```
 
 ## Usage
 
 ```js
-const { MeterProvider }  = require('@opentelemetry/metrics');
+const { MeterProvider }  = require('@opentelemetry/sdk-metrics-base');
 const { MetricExporter } = require('@google-cloud/opentelemetry-cloud-monitoring-exporter');
 
 const exporter = new MetricExporter();

--- a/packages/opentelemetry-cloud-monitoring-exporter/package-lock.json
+++ b/packages/opentelemetry-cloud-monitoring-exporter/package-lock.json
@@ -9,16 +9,16 @@
 			"version": "0.11.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^0.24.0",
+				"@opentelemetry/semantic-conventions": "^0.25.0",
 				"google-auth-library": "^7.0.0",
 				"googleapis": "^87.0.0"
 			},
 			"devDependencies": {
 				"@opentelemetry/api": "1.0.3",
-				"@opentelemetry/api-metrics": "0.24.0",
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/metrics": "0.24.0",
-				"@opentelemetry/resources": "0.24.0",
+				"@opentelemetry/api-metrics": "0.25.0",
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/resources": "0.25.0",
+				"@opentelemetry/sdk-metrics-base": "0.25.0",
 				"@types/mocha": "9.0.0",
 				"@types/nock": "11.1.0",
 				"@types/node": "14.17.17",
@@ -38,9 +38,9 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.0.0",
-				"@opentelemetry/core": "^0.24.0",
-				"@opentelemetry/metrics": "^0.24.0",
-				"@opentelemetry/resources": "^0.24.0"
+				"@opentelemetry/core": "^0.25.0",
+				"@opentelemetry/resources": "^0.25.0",
+				"@opentelemetry/sdk-metrics-base": "^0.25.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -511,71 +511,71 @@
 			}
 		},
 		"node_modules/@opentelemetry/api-metrics": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.24.0.tgz",
-			"integrity": "sha512-hdpkMeVlRGTuMshD2ZFaDjA/U0cZTkxUkJFvS/4yOiWfw+kEASmGE+U0/i9lbdQKuCR7X1rXSjbcYumlHcMG+A==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.25.0.tgz",
+			"integrity": "sha512-9T0c9NQAEGRujUC7HzPa2/qZ5px/UvB2sfSU5CAKFRrAlDl2gn25B0oUbDqSRHW/IG1X2rnQ3z2bBQkJyJvE4g==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.25.0.tgz",
+			"integrity": "sha512-8OTWF4vfCENU112XB5ElLqf0eq/FhsY0SBvvY65vB3+fbZ2Oi+CPsRASrUZWGtC9MJ5rK2lBlY+/jI4a/NPPBg==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
+				"@opentelemetry/semantic-conventions": "0.25.0",
+				"semver": "^7.3.5"
 			},
 			"engines": {
 				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
-		"node_modules/@opentelemetry/metrics": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/metrics/-/metrics-0.24.0.tgz",
-			"integrity": "sha512-QqmQCzrSuJE+sCOJ2xXNhctWPp/Am9ILs0Y01MDS08PRJoK20akKHM7eC4oU8ZdXphMg8rYgW2w7tY8rqvYnJg==",
+		"node_modules/@opentelemetry/resources": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.25.0.tgz",
+			"integrity": "sha512-O46u53vDBlxCML8O9dIjsRcCC2VT5ri1upwhp02ITobgJ16aVD/iScCo1lPl/x2E7yq9uwzMINENiiYZRFb6XA==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/api-metrics": "0.24.0",
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/resources": "0.24.0",
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.25.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.0.2"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-metrics-base": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.25.0.tgz",
+			"integrity": "sha512-7fwPlAFB5Xw8mnVQfq0wqKNw3RXiAMad9T1bk5Sza9LK/L6hz8RTuHWCsFMsj+1OOSAaiPFuUMYrK1J75+2IAg==",
+			"dev": true,
+			"dependencies": {
+				"@opentelemetry/api-metrics": "0.25.0",
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/resources": "0.25.0",
 				"lodash.merge": "^4.6.2"
 			},
 			"engines": {
 				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
-			}
-		},
-		"node_modules/@opentelemetry/resources": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-			"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
-			"dev": true,
-			"dependencies": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+			"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg==",
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -4612,9 +4612,9 @@
 			"dev": true
 		},
 		"node_modules/semver": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -5988,48 +5988,48 @@
 			"dev": true
 		},
 		"@opentelemetry/api-metrics": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.24.0.tgz",
-			"integrity": "sha512-hdpkMeVlRGTuMshD2ZFaDjA/U0cZTkxUkJFvS/4yOiWfw+kEASmGE+U0/i9lbdQKuCR7X1rXSjbcYumlHcMG+A==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.25.0.tgz",
+			"integrity": "sha512-9T0c9NQAEGRujUC7HzPa2/qZ5px/UvB2sfSU5CAKFRrAlDl2gn25B0oUbDqSRHW/IG1X2rnQ3z2bBQkJyJvE4g==",
 			"dev": true,
 			"requires": {}
 		},
 		"@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.25.0.tgz",
+			"integrity": "sha512-8OTWF4vfCENU112XB5ElLqf0eq/FhsY0SBvvY65vB3+fbZ2Oi+CPsRASrUZWGtC9MJ5rK2lBlY+/jI4a/NPPBg==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
-			}
-		},
-		"@opentelemetry/metrics": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/metrics/-/metrics-0.24.0.tgz",
-			"integrity": "sha512-QqmQCzrSuJE+sCOJ2xXNhctWPp/Am9ILs0Y01MDS08PRJoK20akKHM7eC4oU8ZdXphMg8rYgW2w7tY8rqvYnJg==",
-			"dev": true,
-			"requires": {
-				"@opentelemetry/api-metrics": "0.24.0",
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/resources": "0.24.0",
-				"lodash.merge": "^4.6.2"
+				"@opentelemetry/semantic-conventions": "0.25.0",
+				"semver": "^7.3.5"
 			}
 		},
 		"@opentelemetry/resources": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-			"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.25.0.tgz",
+			"integrity": "sha512-O46u53vDBlxCML8O9dIjsRcCC2VT5ri1upwhp02ITobgJ16aVD/iScCo1lPl/x2E7yq9uwzMINENiiYZRFb6XA==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.25.0"
+			}
+		},
+		"@opentelemetry/sdk-metrics-base": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.25.0.tgz",
+			"integrity": "sha512-7fwPlAFB5Xw8mnVQfq0wqKNw3RXiAMad9T1bk5Sza9LK/L6hz8RTuHWCsFMsj+1OOSAaiPFuUMYrK1J75+2IAg==",
+			"dev": true,
+			"requires": {
+				"@opentelemetry/api-metrics": "0.25.0",
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/resources": "0.25.0",
+				"lodash.merge": "^4.6.2"
 			}
 		},
 		"@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA=="
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+			"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg=="
 		},
 		"@sindresorhus/is": {
 			"version": "0.14.0",
@@ -9231,9 +9231,9 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 			"dev": true,
 			"requires": {
 				"lru-cache": "^6.0.0"

--- a/packages/opentelemetry-cloud-monitoring-exporter/package.json
+++ b/packages/opentelemetry-cloud-monitoring-exporter/package.json
@@ -39,10 +39,10 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.3",
-    "@opentelemetry/api-metrics": "0.24.0",
-    "@opentelemetry/core": "0.24.0",
-    "@opentelemetry/metrics": "0.24.0",
-    "@opentelemetry/resources": "0.24.0",
+    "@opentelemetry/api-metrics": "0.25.0",
+    "@opentelemetry/core": "0.25.0",
+    "@opentelemetry/sdk-metrics-base": "0.25.0",
+    "@opentelemetry/resources": "0.25.0",
     "@types/mocha": "9.0.0",
     "@types/nock": "11.1.0",
     "@types/node": "14.17.17",
@@ -59,14 +59,14 @@
   },
   "dependencies": {
     "@google-cloud/opentelemetry-resource-util": "^0.11.0",
-    "@opentelemetry/semantic-conventions": "^0.24.0",
+    "@opentelemetry/semantic-conventions": "^0.25.0",
     "google-auth-library": "^7.0.0",
     "googleapis": "^87.0.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/core": "^0.24.0",
-    "@opentelemetry/metrics": "^0.24.0",
-    "@opentelemetry/resources": "^0.24.0"
+    "@opentelemetry/core": "^0.25.0",
+    "@opentelemetry/sdk-metrics-base": "^0.25.0",
+    "@opentelemetry/resources": "^0.25.0"
   }
 }

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
@@ -16,7 +16,7 @@ import {
   MetricExporter as IMetricExporter,
   MetricRecord,
   MetricDescriptor as OTMetricDescriptor,
-} from '@opentelemetry/metrics';
+} from '@opentelemetry/sdk-metrics-base';
 import {ExportResult, ExportResultCode, VERSION} from '@opentelemetry/core';
 import {ExporterOptions} from './external-types';
 import {GoogleAuth, JWT} from 'google-auth-library';

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -19,7 +19,7 @@ import {
   Histogram as OTHistogram,
   Point as OTPoint,
   PointValueType,
-} from '@opentelemetry/metrics';
+} from '@opentelemetry/sdk-metrics-base';
 import {ValueType as OTValueType} from '@opentelemetry/api-metrics';
 import {mapOtelResourceToMonitoredResource} from '@google-cloud/opentelemetry-resource-util';
 import {

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
@@ -19,7 +19,7 @@ import * as nock from 'nock';
 import * as sinon from 'sinon';
 import {MetricExporter} from '../src';
 import {ExportResult, ExportResultCode} from '@opentelemetry/core';
-import {MeterProvider} from '@opentelemetry/metrics';
+import {MeterProvider} from '@opentelemetry/sdk-metrics-base';
 import {Labels} from '@opentelemetry/api-metrics';
 
 import type {monitoring_v3} from 'googleapis';

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/transform.test.ts
@@ -25,7 +25,7 @@ import {
   Point as OTPoint,
   MeterProvider,
   Histogram,
-} from '@opentelemetry/metrics';
+} from '@opentelemetry/sdk-metrics-base';
 import {SemanticResourceAttributes} from '@opentelemetry/semantic-conventions';
 import {ValueType as OTValueType, Labels} from '@opentelemetry/api-metrics';
 import {MetricKind, ValueType, MetricDescriptor} from '../src/types';

--- a/packages/opentelemetry-cloud-trace-exporter/package-lock.json
+++ b/packages/opentelemetry-cloud-trace-exporter/package-lock.json
@@ -16,8 +16,8 @@
 			},
 			"devDependencies": {
 				"@opentelemetry/api": "1.0.3",
-				"@opentelemetry/resources": "0.24.0",
-				"@opentelemetry/tracing": "0.24.0",
+				"@opentelemetry/resources": "0.25.0",
+				"@opentelemetry/sdk-trace-base": "0.25.0",
 				"@types/mocha": "9.0.0",
 				"@types/node": "14.17.17",
 				"@types/sinon": "10.0.2",
@@ -36,9 +36,9 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.0.0",
-				"@opentelemetry/core": "^0.24.0",
-				"@opentelemetry/resources": "^0.24.0",
-				"@opentelemetry/tracing": "^0.24.0"
+				"@opentelemetry/core": "^0.25.0",
+				"@opentelemetry/resources": "^0.25.0",
+				"@opentelemetry/sdk-trace-base": "^0.25.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -540,24 +540,32 @@
 			}
 		},
 		"node_modules/@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.25.0.tgz",
+			"integrity": "sha512-8OTWF4vfCENU112XB5ElLqf0eq/FhsY0SBvvY65vB3+fbZ2Oi+CPsRASrUZWGtC9MJ5rK2lBlY+/jI4a/NPPBg==",
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
+				"@opentelemetry/semantic-conventions": "0.25.0",
+				"semver": "^7.3.5"
 			},
 			"engines": {
 				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
+			}
+		},
+		"node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+			"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg==",
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/core/node_modules/semver": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -569,45 +577,55 @@
 			}
 		},
 		"node_modules/@opentelemetry/resources": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-			"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.25.0.tgz",
+			"integrity": "sha512-O46u53vDBlxCML8O9dIjsRcCC2VT5ri1upwhp02ITobgJ16aVD/iScCo1lPl/x2E7yq9uwzMINENiiYZRFb6XA==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.25.0"
 			},
 			"engines": {
 				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
-		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+		"node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+			"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg==",
+			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
-		"node_modules/@opentelemetry/tracing": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.24.0.tgz",
-			"integrity": "sha512-sTLEs1SIon3xV8vLe53PzfbU0FahoxL9NPY/CYvA1mwGbMu4zHkHAjqy1Tc8JmqRrfa+XrHkmzeSM4hrvloBaA==",
+		"node_modules/@opentelemetry/sdk-trace-base": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-0.25.0.tgz",
+			"integrity": "sha512-TInkLSF/ThM3GNVM+9tgnCVjyNLnRxvAkG585Fhu0HNwaEtCTUwI0r7AvMRIREOreeRWttBG6kvT0LOKdo8yjw==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/resources": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0",
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/resources": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.25.0",
 				"lodash.merge": "^4.6.2"
 			},
 			"engines": {
 				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+			"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@protobufjs/aspromise": {
@@ -6034,18 +6052,23 @@
 			"integrity": "sha512-puWxACExDe9nxbBB3lOymQFrLYml2dVOrd7USiVRnSbgXE+KwBu+HxFvxrzfqsiSda9IWsXJG1ef7C1O2/GmKQ=="
 		},
 		"@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.25.0.tgz",
+			"integrity": "sha512-8OTWF4vfCENU112XB5ElLqf0eq/FhsY0SBvvY65vB3+fbZ2Oi+CPsRASrUZWGtC9MJ5rK2lBlY+/jI4a/NPPBg==",
 			"requires": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
+				"@opentelemetry/semantic-conventions": "0.25.0",
+				"semver": "^7.3.5"
 			},
 			"dependencies": {
+				"@opentelemetry/semantic-conventions": {
+					"version": "0.25.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+					"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg=="
+				},
 				"semver": {
-					"version": "7.3.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
@@ -6053,30 +6076,41 @@
 			}
 		},
 		"@opentelemetry/resources": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-			"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.25.0.tgz",
+			"integrity": "sha512-O46u53vDBlxCML8O9dIjsRcCC2VT5ri1upwhp02ITobgJ16aVD/iScCo1lPl/x2E7yq9uwzMINENiiYZRFb6XA==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.25.0"
+			},
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": {
+					"version": "0.25.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+					"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg==",
+					"dev": true
+				}
 			}
 		},
-		"@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA=="
-		},
-		"@opentelemetry/tracing": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.24.0.tgz",
-			"integrity": "sha512-sTLEs1SIon3xV8vLe53PzfbU0FahoxL9NPY/CYvA1mwGbMu4zHkHAjqy1Tc8JmqRrfa+XrHkmzeSM4hrvloBaA==",
+		"@opentelemetry/sdk-trace-base": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-0.25.0.tgz",
+			"integrity": "sha512-TInkLSF/ThM3GNVM+9tgnCVjyNLnRxvAkG585Fhu0HNwaEtCTUwI0r7AvMRIREOreeRWttBG6kvT0LOKdo8yjw==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/resources": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0",
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/resources": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.25.0",
 				"lodash.merge": "^4.6.2"
+			},
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": {
+					"version": "0.25.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+					"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg==",
+					"dev": true
+				}
 			}
 		},
 		"@protobufjs/aspromise": {

--- a/packages/opentelemetry-cloud-trace-exporter/package.json
+++ b/packages/opentelemetry-cloud-trace-exporter/package.json
@@ -39,8 +39,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.3",
-    "@opentelemetry/resources": "0.24.0",
-    "@opentelemetry/tracing": "0.24.0",
+    "@opentelemetry/resources": "0.25.0",
+    "@opentelemetry/sdk-trace-base": "0.25.0",
     "@types/mocha": "9.0.0",
     "@types/node": "14.17.17",
     "@types/sinon": "10.0.2",
@@ -63,8 +63,8 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/core": "^0.24.0",
-    "@opentelemetry/resources": "^0.24.0",
-    "@opentelemetry/tracing": "^0.24.0"
+    "@opentelemetry/core": "^0.25.0",
+    "@opentelemetry/resources": "^0.25.0",
+    "@opentelemetry/sdk-trace-base": "^0.25.0"
   }
 }

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {ExportResult, ExportResultCode} from '@opentelemetry/core';
-import {ReadableSpan, SpanExporter} from '@opentelemetry/tracing';
+import {ReadableSpan, SpanExporter} from '@opentelemetry/sdk-trace-base';
 import {diag} from '@opentelemetry/api';
 import * as protoloader from '@grpc/proto-loader';
 import * as protofiles from 'google-proto-files';

--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -15,7 +15,7 @@
 import * as ot from '@opentelemetry/api';
 import {VERSION as CORE_VERSION} from '@opentelemetry/core';
 import {Resource} from '@opentelemetry/resources';
-import {ReadableSpan} from '@opentelemetry/tracing';
+import {ReadableSpan} from '@opentelemetry/sdk-trace-base';
 import {
   AttributeMap,
   Attributes,

--- a/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
@@ -16,7 +16,7 @@ import * as types from '@opentelemetry/api';
 import {diag, TraceFlags} from '@opentelemetry/api';
 import {ExportResult, ExportResultCode} from '@opentelemetry/core';
 import {Resource} from '@opentelemetry/resources';
-import {ReadableSpan} from '@opentelemetry/tracing';
+import {ReadableSpan} from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as protoloader from '@grpc/proto-loader';

--- a/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
@@ -14,7 +14,7 @@
 import * as api from '@opentelemetry/api';
 import {VERSION as CORE_VERSION} from '@opentelemetry/core';
 import {Resource} from '@opentelemetry/resources';
-import type {ReadableSpan} from '@opentelemetry/tracing';
+import type {ReadableSpan} from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
 import {getReadableSpanTransformer} from '../src/transform';
 import {LinkType, Span, Code, Status, SpanKind} from '../src/types';

--- a/packages/opentelemetry-cloud-trace-propagator/README.md
+++ b/packages/opentelemetry-cloud-trace-propagator/README.md
@@ -22,7 +22,7 @@ Format:
 ## Usage
 
 ```javascript
-const { NodeTracerProvider } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
 const { CloudPropagator } = require('@google-cloud/opentelemetry-cloud-trace-propagator');
 
 const provider = new NodeTracerProvider();

--- a/packages/opentelemetry-cloud-trace-propagator/package-lock.json
+++ b/packages/opentelemetry-cloud-trace-propagator/package-lock.json
@@ -13,7 +13,7 @@
 			},
 			"devDependencies": {
 				"@opentelemetry/api": "1.0.3",
-				"@opentelemetry/core": "0.24.0",
+				"@opentelemetry/core": "0.25.0",
 				"@types/mocha": "9.0.0",
 				"@types/node": "14.17.17",
 				"codecov": "3.8.3",
@@ -29,7 +29,7 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.0.0",
-				"@opentelemetry/core": "^0.24.0"
+				"@opentelemetry/core": "^0.25.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -500,25 +500,25 @@
 			}
 		},
 		"node_modules/@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.25.0.tgz",
+			"integrity": "sha512-8OTWF4vfCENU112XB5ElLqf0eq/FhsY0SBvvY65vB3+fbZ2Oi+CPsRASrUZWGtC9MJ5rK2lBlY+/jI4a/NPPBg==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
+				"@opentelemetry/semantic-conventions": "0.25.0",
+				"semver": "^7.3.5"
 			},
 			"engines": {
 				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+			"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
@@ -4176,9 +4176,9 @@
 			"dev": true
 		},
 		"node_modules/semver": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -5500,19 +5500,19 @@
 			"dev": true
 		},
 		"@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.25.0.tgz",
+			"integrity": "sha512-8OTWF4vfCENU112XB5ElLqf0eq/FhsY0SBvvY65vB3+fbZ2Oi+CPsRASrUZWGtC9MJ5rK2lBlY+/jI4a/NPPBg==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
+				"@opentelemetry/semantic-conventions": "0.25.0",
+				"semver": "^7.3.5"
 			}
 		},
 		"@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+			"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg==",
 			"dev": true
 		},
 		"@sindresorhus/is": {
@@ -8386,9 +8386,9 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 			"dev": true,
 			"requires": {
 				"lru-cache": "^6.0.0"

--- a/packages/opentelemetry-cloud-trace-propagator/package.json
+++ b/packages/opentelemetry-cloud-trace-propagator/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.3",
-    "@opentelemetry/core": "0.24.0",
+    "@opentelemetry/core": "0.25.0",
     "@types/mocha": "9.0.0",
     "@types/node": "14.17.17",
     "codecov": "3.8.3",
@@ -55,6 +55,6 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/core": "^0.24.0"
+    "@opentelemetry/core": "^0.25.0"
   }
 }

--- a/packages/opentelemetry-resource-util/package-lock.json
+++ b/packages/opentelemetry-resource-util/package-lock.json
@@ -10,8 +10,8 @@
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@opentelemetry/api": "1.0.3",
-				"@opentelemetry/resources": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0",
+				"@opentelemetry/resources": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.25.0",
 				"@types/mocha": "9.0.0",
 				"@types/node": "14.17.17",
 				"codecov": "3.8.3",
@@ -25,8 +25,8 @@
 				"node": ">=10"
 			},
 			"peerDependencies": {
-				"@opentelemetry/resources": "^0.24.0",
-				"@opentelemetry/semantic-conventions": "^0.24.0"
+				"@opentelemetry/resources": "^0.25.0",
+				"@opentelemetry/semantic-conventions": "^0.25.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -497,41 +497,41 @@
 			}
 		},
 		"node_modules/@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.25.0.tgz",
+			"integrity": "sha512-8OTWF4vfCENU112XB5ElLqf0eq/FhsY0SBvvY65vB3+fbZ2Oi+CPsRASrUZWGtC9MJ5rK2lBlY+/jI4a/NPPBg==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
+				"@opentelemetry/semantic-conventions": "0.25.0",
+				"semver": "^7.3.5"
 			},
 			"engines": {
 				"node": ">=8.5.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/resources": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-			"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.25.0.tgz",
+			"integrity": "sha512-O46u53vDBlxCML8O9dIjsRcCC2VT5ri1upwhp02ITobgJ16aVD/iScCo1lPl/x2E7yq9uwzMINENiiYZRFb6XA==",
 			"dev": true,
 			"dependencies": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.25.0"
 			},
 			"engines": {
 				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+			"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
@@ -4213,9 +4213,9 @@
 			"dev": true
 		},
 		"node_modules/semver": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -5537,29 +5537,29 @@
 			"dev": true
 		},
 		"@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.25.0.tgz",
+			"integrity": "sha512-8OTWF4vfCENU112XB5ElLqf0eq/FhsY0SBvvY65vB3+fbZ2Oi+CPsRASrUZWGtC9MJ5rK2lBlY+/jI4a/NPPBg==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
+				"@opentelemetry/semantic-conventions": "0.25.0",
+				"semver": "^7.3.5"
 			}
 		},
 		"@opentelemetry/resources": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-			"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.25.0.tgz",
+			"integrity": "sha512-O46u53vDBlxCML8O9dIjsRcCC2VT5ri1upwhp02ITobgJ16aVD/iScCo1lPl/x2E7yq9uwzMINENiiYZRFb6XA==",
 			"dev": true,
 			"requires": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.25.0"
 			}
 		},
 		"@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+			"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg==",
 			"dev": true
 		},
 		"@sindresorhus/is": {
@@ -8446,9 +8446,9 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 			"dev": true,
 			"requires": {
 				"lru-cache": "^6.0.0"

--- a/packages/opentelemetry-resource-util/package.json
+++ b/packages/opentelemetry-resource-util/package.json
@@ -39,8 +39,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.3",
-    "@opentelemetry/resources": "0.24.0",
-    "@opentelemetry/semantic-conventions": "0.24.0",
+    "@opentelemetry/resources": "0.25.0",
+    "@opentelemetry/semantic-conventions": "0.25.0",
     "@types/mocha": "9.0.0",
     "@types/node": "14.17.17",
     "codecov": "3.8.3",
@@ -51,7 +51,7 @@
     "typescript": "4.4.3"
   },
   "peerDependencies": {
-    "@opentelemetry/resources": "^0.24.0",
-    "@opentelemetry/semantic-conventions": "^0.24.0"
+    "@opentelemetry/resources": "^0.25.0",
+    "@opentelemetry/semantic-conventions": "^0.25.0"
   }
 }

--- a/samples/trace/README.md
+++ b/samples/trace/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-This example shows how to use [@opentelemetry/node](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-node) to instrument a simple Node.js application - e.g. a batch job - and export spans to [Google Cloud Trace](https://cloud.google.com/trace/).
+This example shows how to use [@opentelemetry/sdk-trace-node](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node) to instrument a simple Node.js application - e.g. a batch job - and export spans to [Google Cloud Trace](https://cloud.google.com/trace/).
 
 ## Installation
 

--- a/samples/trace/index.js
+++ b/samples/trace/index.js
@@ -14,13 +14,15 @@
 //
 
 // [START opentelemetry_trace_samples]
-'use strict';
+"use strict";
 
 // [START opentelemetry_trace_import]
-const opentelemetry = require('@opentelemetry/api');
-const {NodeTracerProvider} = require('@opentelemetry/node');
-const {SimpleSpanProcessor} = require('@opentelemetry/tracing');
-const { TraceExporter } = require('@google-cloud/opentelemetry-cloud-trace-exporter');
+const opentelemetry = require("@opentelemetry/api");
+const { NodeTracerProvider } = require("@opentelemetry/sdk-trace-node");
+const { SimpleSpanProcessor } = require("@opentelemetry/sdk-trace-base");
+const {
+  TraceExporter,
+} = require("@google-cloud/opentelemetry-cloud-trace-exporter");
 // [END opentelemetry_trace_import]
 
 // [START setup_exporter]
@@ -44,24 +46,24 @@ provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
 // Initialize the OpenTelemetry APIs to use the
 // NodeTracerProvider bindings
 opentelemetry.trace.setGlobalTracerProvider(provider);
-const tracer = opentelemetry.trace.getTracer('basic');
+const tracer = opentelemetry.trace.getTracer("basic");
 
 // Create a span.
-const span = tracer.startSpan('foo');
+const span = tracer.startSpan("foo");
 
 // Set attributes to the span.
-span.setAttribute('key', 'value');
+span.setAttribute("key", "value");
 
 // Annotate our span to capture metadata about our operation
-span.addEvent('invoking work');
+span.addEvent("invoking work");
 
 // simulate some random work.
-for (let i = 0; i <= Math.floor(Math.random() * 40000000); i += 1) { }
+for (let i = 0; i <= Math.floor(Math.random() * 40000000); i += 1) {}
 
 // Be sure to end the span.
 span.end();
 // [END opentelemetry_trace_custom_span]
 
-console.log('Done recording traces.');
+console.log("Done recording traces.");
 
 // [END opentelemetry_trace_samples]

--- a/samples/trace/package-lock.json
+++ b/samples/trace/package-lock.json
@@ -10,132 +10,155 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.0.0",
-				"@opentelemetry/node": "^0.24.0",
-				"@opentelemetry/tracing": "^0.24.0"
+				"@opentelemetry/sdk-trace-base": "^0.25.0",
+				"@opentelemetry/sdk-trace-node": "^0.25.0"
 			},
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/@opentelemetry/api": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.1.tgz",
-			"integrity": "sha512-H5Djcc2txGAINgf3TNaq4yFofYSIK3722PM89S/3R8FuI/eqi1UscajlXk7EBkG9s2pxss/q6SHlpturaavXaw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.3.tgz",
+			"integrity": "sha512-puWxACExDe9nxbBB3lOymQFrLYml2dVOrd7USiVRnSbgXE+KwBu+HxFvxrzfqsiSda9IWsXJG1ef7C1O2/GmKQ==",
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
-		"node_modules/@opentelemetry/context-async-hooks": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.24.0.tgz",
-			"integrity": "sha512-Db8AgMByBEFKLJGSUBlNq4Un/Tqzj5W0hTxx3hIic8DvBwqbvUvkMGuiQYLKE2Ay21cLYMT01xK4TEKz0OxADw==",
-			"engines": {
-				"node": ">=8.1.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
-			}
-		},
-		"node_modules/@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+		"node_modules/@opentelemetry/sdk-trace-base": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-0.25.0.tgz",
+			"integrity": "sha512-TInkLSF/ThM3GNVM+9tgnCVjyNLnRxvAkG585Fhu0HNwaEtCTUwI0r7AvMRIREOreeRWttBG6kvT0LOKdo8yjw==",
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
-			},
-			"engines": {
-				"node": ">=8.5.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
-			}
-		},
-		"node_modules/@opentelemetry/node": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/node/-/node-0.24.0.tgz",
-			"integrity": "sha512-Sy8QooZFOeVUcJIKetw5xsq15/1ivZovWg0RnKWtzURMQrcOxmQ3bGrXPORklOJxOtf5snDHgT37Y7dBgr+c+g==",
-			"dependencies": {
-				"@opentelemetry/context-async-hooks": "0.24.0",
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/propagator-b3": "0.24.0",
-				"@opentelemetry/propagator-jaeger": "0.24.0",
-				"@opentelemetry/tracing": "0.24.0",
-				"semver": "^7.1.3"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
-			}
-		},
-		"node_modules/@opentelemetry/propagator-b3": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-0.24.0.tgz",
-			"integrity": "sha512-iV7KSN0LkEAkeVCbhaIJAgTEb7HCnVkprmpgkL6q79rP3vTW4dylwfBYgIwod7y0GT4Ofgomm0NrwwWiuGLbQA==",
-			"dependencies": {
-				"@opentelemetry/core": "0.24.0"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
-			}
-		},
-		"node_modules/@opentelemetry/propagator-jaeger": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-0.24.0.tgz",
-			"integrity": "sha512-QXCxBwuSka+vXbBZdumtF7YKO84gwTyKy3GelZV5BPlgWoge0AbLR3DfsO9Beu13pmD+4PyuwMw3LfYsgG1+3g==",
-			"dependencies": {
-				"@opentelemetry/core": "0.24.0"
-			},
-			"engines": {
-				"node": ">=8.5.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
-			}
-		},
-		"node_modules/@opentelemetry/resources": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-			"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
-			"dependencies": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
-			}
-		},
-		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/@opentelemetry/tracing": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.24.0.tgz",
-			"integrity": "sha512-sTLEs1SIon3xV8vLe53PzfbU0FahoxL9NPY/CYvA1mwGbMu4zHkHAjqy1Tc8JmqRrfa+XrHkmzeSM4hrvloBaA==",
-			"dependencies": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/resources": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0",
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/resources": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.25.0",
 				"lodash.merge": "^4.6.2"
 			},
 			"engines": {
 				"node": ">=8.0.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.1"
+				"@opentelemetry/api": "^1.0.2"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.25.0.tgz",
+			"integrity": "sha512-8OTWF4vfCENU112XB5ElLqf0eq/FhsY0SBvvY65vB3+fbZ2Oi+CPsRASrUZWGtC9MJ5rK2lBlY+/jI4a/NPPBg==",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "0.25.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": ">=8.5.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.0.2"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.25.0.tgz",
+			"integrity": "sha512-O46u53vDBlxCML8O9dIjsRcCC2VT5ri1upwhp02ITobgJ16aVD/iScCo1lPl/x2E7yq9uwzMINENiiYZRFb6XA==",
+			"dependencies": {
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.25.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.0.2"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+			"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg==",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-node": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-0.25.0.tgz",
+			"integrity": "sha512-j3bI3uhopgowdrJWIWkee/W5j0zeNk5Wydi7YGLayci+g/Ue3QYJaKlqaK2V7Rda1N8GY5d+k1CGQ3vE0DCOoQ==",
+			"dependencies": {
+				"@opentelemetry/context-async-hooks": "0.25.0",
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/propagator-b3": "0.25.0",
+				"@opentelemetry/propagator-jaeger": "0.25.0",
+				"@opentelemetry/sdk-trace-base": "0.25.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.0.2"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/context-async-hooks": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.25.0.tgz",
+			"integrity": "sha512-XNjlBalbN82qCfkgPpof6g3oU/LZoyoGGrluA+cy4AKWjJ9FdEZqKwX2p2WHxEuWm8TrHh5HxqEXH5OH2o/5tw==",
+			"engines": {
+				"node": ">=8.1.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.0.2"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.25.0.tgz",
+			"integrity": "sha512-8OTWF4vfCENU112XB5ElLqf0eq/FhsY0SBvvY65vB3+fbZ2Oi+CPsRASrUZWGtC9MJ5rK2lBlY+/jI4a/NPPBg==",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "0.25.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": ">=8.5.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.0.2"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/propagator-b3": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-0.25.0.tgz",
+			"integrity": "sha512-FMdy4YOZO56w2+pxsXWARWa+2F8N7fHW+ZfSFB937Q/oyOZ/2dhj3Ep12gqIH/qV6+kAblgiqOAMyOcnwBCUog==",
+			"dependencies": {
+				"@opentelemetry/core": "0.25.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.0.2"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/propagator-jaeger": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-0.25.0.tgz",
+			"integrity": "sha512-GipAgda8xTQa5YrnCQBzWVcUQO7vMsz2AROFse3QXnmgdKz07bIBQFqQLXvr4SHr38LiOVpZWe7Nvfqtuz/0HA==",
+			"dependencies": {
+				"@opentelemetry/core": "0.25.0"
+			},
+			"engines": {
+				"node": ">=8.5.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.0.2"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+			"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg==",
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/lodash.merge": {
@@ -176,77 +199,95 @@
 	},
 	"dependencies": {
 		"@opentelemetry/api": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.1.tgz",
-			"integrity": "sha512-H5Djcc2txGAINgf3TNaq4yFofYSIK3722PM89S/3R8FuI/eqi1UscajlXk7EBkG9s2pxss/q6SHlpturaavXaw=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.3.tgz",
+			"integrity": "sha512-puWxACExDe9nxbBB3lOymQFrLYml2dVOrd7USiVRnSbgXE+KwBu+HxFvxrzfqsiSda9IWsXJG1ef7C1O2/GmKQ=="
 		},
-		"@opentelemetry/context-async-hooks": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.24.0.tgz",
-			"integrity": "sha512-Db8AgMByBEFKLJGSUBlNq4Un/Tqzj5W0hTxx3hIic8DvBwqbvUvkMGuiQYLKE2Ay21cLYMT01xK4TEKz0OxADw==",
-			"requires": {}
-		},
-		"@opentelemetry/core": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-			"integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+		"@opentelemetry/sdk-trace-base": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-0.25.0.tgz",
+			"integrity": "sha512-TInkLSF/ThM3GNVM+9tgnCVjyNLnRxvAkG585Fhu0HNwaEtCTUwI0r7AvMRIREOreeRWttBG6kvT0LOKdo8yjw==",
 			"requires": {
-				"@opentelemetry/semantic-conventions": "0.24.0",
-				"semver": "^7.1.3"
-			}
-		},
-		"@opentelemetry/node": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/node/-/node-0.24.0.tgz",
-			"integrity": "sha512-Sy8QooZFOeVUcJIKetw5xsq15/1ivZovWg0RnKWtzURMQrcOxmQ3bGrXPORklOJxOtf5snDHgT37Y7dBgr+c+g==",
-			"requires": {
-				"@opentelemetry/context-async-hooks": "0.24.0",
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/propagator-b3": "0.24.0",
-				"@opentelemetry/propagator-jaeger": "0.24.0",
-				"@opentelemetry/tracing": "0.24.0",
-				"semver": "^7.1.3"
-			}
-		},
-		"@opentelemetry/propagator-b3": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-0.24.0.tgz",
-			"integrity": "sha512-iV7KSN0LkEAkeVCbhaIJAgTEb7HCnVkprmpgkL6q79rP3vTW4dylwfBYgIwod7y0GT4Ofgomm0NrwwWiuGLbQA==",
-			"requires": {
-				"@opentelemetry/core": "0.24.0"
-			}
-		},
-		"@opentelemetry/propagator-jaeger": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-0.24.0.tgz",
-			"integrity": "sha512-QXCxBwuSka+vXbBZdumtF7YKO84gwTyKy3GelZV5BPlgWoge0AbLR3DfsO9Beu13pmD+4PyuwMw3LfYsgG1+3g==",
-			"requires": {
-				"@opentelemetry/core": "0.24.0"
-			}
-		},
-		"@opentelemetry/resources": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-			"integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
-			"requires": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0"
-			}
-		},
-		"@opentelemetry/semantic-conventions": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-			"integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA=="
-		},
-		"@opentelemetry/tracing": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.24.0.tgz",
-			"integrity": "sha512-sTLEs1SIon3xV8vLe53PzfbU0FahoxL9NPY/CYvA1mwGbMu4zHkHAjqy1Tc8JmqRrfa+XrHkmzeSM4hrvloBaA==",
-			"requires": {
-				"@opentelemetry/core": "0.24.0",
-				"@opentelemetry/resources": "0.24.0",
-				"@opentelemetry/semantic-conventions": "0.24.0",
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/resources": "0.25.0",
+				"@opentelemetry/semantic-conventions": "0.25.0",
 				"lodash.merge": "^4.6.2"
+			},
+			"dependencies": {
+				"@opentelemetry/core": {
+					"version": "0.25.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.25.0.tgz",
+					"integrity": "sha512-8OTWF4vfCENU112XB5ElLqf0eq/FhsY0SBvvY65vB3+fbZ2Oi+CPsRASrUZWGtC9MJ5rK2lBlY+/jI4a/NPPBg==",
+					"requires": {
+						"@opentelemetry/semantic-conventions": "0.25.0",
+						"semver": "^7.3.5"
+					}
+				},
+				"@opentelemetry/resources": {
+					"version": "0.25.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.25.0.tgz",
+					"integrity": "sha512-O46u53vDBlxCML8O9dIjsRcCC2VT5ri1upwhp02ITobgJ16aVD/iScCo1lPl/x2E7yq9uwzMINENiiYZRFb6XA==",
+					"requires": {
+						"@opentelemetry/core": "0.25.0",
+						"@opentelemetry/semantic-conventions": "0.25.0"
+					}
+				},
+				"@opentelemetry/semantic-conventions": {
+					"version": "0.25.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+					"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg=="
+				}
+			}
+		},
+		"@opentelemetry/sdk-trace-node": {
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-0.25.0.tgz",
+			"integrity": "sha512-j3bI3uhopgowdrJWIWkee/W5j0zeNk5Wydi7YGLayci+g/Ue3QYJaKlqaK2V7Rda1N8GY5d+k1CGQ3vE0DCOoQ==",
+			"requires": {
+				"@opentelemetry/context-async-hooks": "0.25.0",
+				"@opentelemetry/core": "0.25.0",
+				"@opentelemetry/propagator-b3": "0.25.0",
+				"@opentelemetry/propagator-jaeger": "0.25.0",
+				"@opentelemetry/sdk-trace-base": "0.25.0",
+				"semver": "^7.3.5"
+			},
+			"dependencies": {
+				"@opentelemetry/context-async-hooks": {
+					"version": "0.25.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-0.25.0.tgz",
+					"integrity": "sha512-XNjlBalbN82qCfkgPpof6g3oU/LZoyoGGrluA+cy4AKWjJ9FdEZqKwX2p2WHxEuWm8TrHh5HxqEXH5OH2o/5tw==",
+					"requires": {}
+				},
+				"@opentelemetry/core": {
+					"version": "0.25.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.25.0.tgz",
+					"integrity": "sha512-8OTWF4vfCENU112XB5ElLqf0eq/FhsY0SBvvY65vB3+fbZ2Oi+CPsRASrUZWGtC9MJ5rK2lBlY+/jI4a/NPPBg==",
+					"requires": {
+						"@opentelemetry/semantic-conventions": "0.25.0",
+						"semver": "^7.3.5"
+					}
+				},
+				"@opentelemetry/propagator-b3": {
+					"version": "0.25.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-0.25.0.tgz",
+					"integrity": "sha512-FMdy4YOZO56w2+pxsXWARWa+2F8N7fHW+ZfSFB937Q/oyOZ/2dhj3Ep12gqIH/qV6+kAblgiqOAMyOcnwBCUog==",
+					"requires": {
+						"@opentelemetry/core": "0.25.0"
+					}
+				},
+				"@opentelemetry/propagator-jaeger": {
+					"version": "0.25.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-0.25.0.tgz",
+					"integrity": "sha512-GipAgda8xTQa5YrnCQBzWVcUQO7vMsz2AROFse3QXnmgdKz07bIBQFqQLXvr4SHr38LiOVpZWe7Nvfqtuz/0HA==",
+					"requires": {
+						"@opentelemetry/core": "0.25.0"
+					}
+				},
+				"@opentelemetry/semantic-conventions": {
+					"version": "0.25.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.25.0.tgz",
+					"integrity": "sha512-V3N+MDBiv0TUlorbgiSqk6CvcP876CYUk/41Tg6s8OIyvniTwprE6vPvFQayuABiVkGlHOxv1Mlvp0w4qNdnVg=="
+				}
 			}
 		},
 		"lodash.merge": {

--- a/samples/trace/package.json
+++ b/samples/trace/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@google-cloud/opentelemetry-cloud-trace-exporter": "^0.11.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/node": "^0.24.0",
-    "@opentelemetry/tracing": "^0.24.0"
+    "@opentelemetry/sdk-trace-node": "^0.25.0",
+    "@opentelemetry/sdk-trace-base": "^0.25.0"
   }
 }


### PR DESCRIPTION
Fixes #314

Upgraded all SDK deps to `0.25.0`, including newly renamed packages:

old pkg name           | new pkg name 
-----------------------|------------------
@opentelemetry/tracing | @opentelemetry/sdk-trace-base 
@opentelemetry/node    | @opentelemetry/sdk-trace-node
@opentelemetry/metrics | @opentelemetry/sdk-metrics-base