### PR TITLE
feat: add optional filter for OTel resource attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "opentelemetry-operations-js",
       "version": "0.4.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",

--- a/packages/opentelemetry-cloud-trace-exporter/README.md
+++ b/packages/opentelemetry-cloud-trace-exporter/README.md
@@ -41,7 +41,7 @@ You can use built-in `SimpleSpanProcessor` or `BatchSpanProcessor` or write your
 
 ## Resource attributes
 
-By default, OpenTelemetry resource attributes are ignored. If you wish to export attributes you set on your resource, you must specify a regexp that should match the attributes you'd like.
+By default, OpenTelemetry resource attributes which do not map to a monitored resource are ignored. If you wish to export other resource attributes, you must specify a regexp that should match the attribute keys you'd like.
 
 For example, if you are setting up a resource with the "service" semantic attributes:
 ```typescript

--- a/packages/opentelemetry-cloud-trace-exporter/README.md
+++ b/packages/opentelemetry-cloud-trace-exporter/README.md
@@ -17,7 +17,7 @@ npm install --save @google-cloud/opentelemetry-cloud-trace-exporter
 ```
 
 ## Usage
-Install the exporter on your application, register the exporter, and start tracing. If you are running in a GCP environment, the exporter will automatically authenticate using the environment's service account. If not, you will need to follow the instructions in  [Authentication](#Authentication).
+Install the exporter on your application, register the exporter, and start tracing. If you are running in a GCP environment, the exporter will automatically authenticate using the environment's service account. If not, you will need to follow the instructions in [Authentication](#Authentication).
 
 ```js
 const { TraceExporter } = require('@google-cloud/opentelemetry-cloud-trace-exporter');
@@ -38,6 +38,33 @@ You can use built-in `SimpleSpanProcessor` or `BatchSpanProcessor` or write your
 
 - [SimpleSpanProcessor](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.4.0/specification/trace/sdk.md#simple-processor): The implementation of `SpanProcessor` that passes ended span directly to the configured `SpanExporter`.
 - [BatchSpanProcessor](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.4.0/specification/trace/sdk.md#batching-processor): The implementation of the `SpanProcessor` that batches ended spans and pushes them to the configured `SpanExporter`. It is recommended to use this `SpanProcessor` for better performance and optimization.
+
+## Resource attributes
+
+By default, OpenTelemetry resource attributes are ignored. If you wish to export attributes you set on your resource, you must specify a regexp that should match the attributes you'd like.
+
+For example, if you are setting up a resource with the "service" semantic attributes:
+```typescript
+const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
+
+const provider = new NodeTracerProvider({
+  // ...
+  resource: new Resource({
+    [SemanticResourceAttributes.SERVICE_NAME]: 'things-service',
+    [SemanticResourceAttributes.SERVICE_NAMESPACE]: 'things',
+    [SemanticResourceAttributes.SERVICE_VERSION]: '1.0.0',
+    [SemanticResourceAttributes.SERVICE_INSTANCE_ID]: 'abc123',
+  }),
+})
+```
+
+You can ensure they are exported by using a regexp that matches them:
+```typescript
+const exporter = new TraceExporter({
+  // will export all resource attributes that start with "service."
+  resourceFilter: /^service\./
+});
+```
 
 ## Authentication
 

--- a/packages/opentelemetry-cloud-trace-exporter/src/external-types.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/external-types.ts
@@ -35,6 +35,12 @@ export interface TraceExporterOptions {
    * Object containing client_email and private_key properties
    */
   credentials?: Credentials;
+  /**
+   * A RegExp used to determine which resource attributes are exported,
+   * attributes that match will be included as span labels.
+   * If not specified, most resource attributes are ignored.
+   */
+  resourceFilter?: RegExp;
 }
 
 export interface Credentials {

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -33,8 +33,10 @@ export class TraceExporter implements SpanExporter {
   private _projectId: string | void | Promise<string | void>;
   private readonly _auth: GoogleAuth;
   private _traceServiceClient?: TraceService = undefined;
+  private _resourceFilter?: RegExp = undefined;
 
   constructor(options: TraceExporterOptions = {}) {
+    this._resourceFilter = options.resourceFilter;
     this._auth = new GoogleAuth({
       credentials: options.credentials,
       keyFile: options.keyFile,
@@ -73,7 +75,9 @@ export class TraceExporter implements SpanExporter {
 
     const namedSpans: NamedSpans = {
       name: `projects/${this._projectId}`,
-      spans: spans.map(getReadableSpanTransformer(this._projectId)),
+      spans: spans.map(
+        getReadableSpanTransformer(this._projectId, this._resourceFilter)
+      ),
     };
 
     const result = await this._batchWriteSpans(namedSpans);

--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -187,11 +187,7 @@ function transformResourceToAttributes(
     const filteredResourceAttributes: [string, ot.SpanAttributeValue][] =
       Object.keys(resource.attributes)
         .filter(key => resourceFilter.test(key))
-        .map(key => [key, resource.attributes[key]]);
-
-    for (const [key, value] of filteredResourceAttributes) {
-      attributes[key] = value;
-    }
+        .forEach(key => { attributes[key] = resource.attributes[key]; });
   }
 
   // global is the "default" so just skip

--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -184,10 +184,11 @@ function transformResourceToAttributes(
   const attributes: ot.SpanAttributes = {};
 
   if (resourceFilter) {
-    const filteredResourceAttributes: [string, ot.SpanAttributeValue][] =
-      Object.keys(resource.attributes)
-        .filter(key => resourceFilter.test(key))
-        .forEach(key => { attributes[key] = resource.attributes[key]; });
+    Object.keys(resource.attributes)
+      .filter(key => resourceFilter.test(key))
+      .forEach(key => {
+        attributes[key] = resource.attributes[key];
+      });
   }
 
   // global is the "default" so just skip

--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -36,7 +36,8 @@ const AGENT_LABEL_KEY = 'g.co/agent';
 const AGENT_LABEL_VALUE = `opentelemetry-js ${CORE_VERSION}; google-cloud-trace-exporter ${VERSION}`;
 
 export function getReadableSpanTransformer(
-  projectId: string
+  projectId: string,
+  resourceFilter?: RegExp | undefined
 ): (span: ReadableSpan) => Span {
   return span => {
     // @todo get dropped attribute count from sdk ReadableSpan
@@ -46,7 +47,7 @@ export function getReadableSpanTransformer(
         [AGENT_LABEL_KEY]: AGENT_LABEL_VALUE,
       }),
       // Add in special g.co/r resource labels
-      transformResourceToAttributes(span.resource, projectId)
+      transformResourceToAttributes(span.resource, projectId, resourceFilter)
     );
 
     const out: Span = {
@@ -173,13 +174,25 @@ function mergeAttributes(...attributeList: Attributes[]): Attributes {
 
 function transformResourceToAttributes(
   resource: Resource,
-  projectId: string
+  projectId: string,
+  resourceFilter?: RegExp
 ): Attributes {
   const monitoredResource = mapOtelResourceToMonitoredResource(
     resource,
     projectId
   );
   const attributes: ot.SpanAttributes = {};
+
+  if (resourceFilter) {
+    const filteredResourceAttributes: [string, ot.SpanAttributeValue][] =
+      Object.keys(resource.attributes)
+        .filter(key => resourceFilter.test(key))
+        .map(key => [key, resource.attributes[key]]);
+
+    for (const [key, value] of filteredResourceAttributes) {
+      attributes[key] = value;
+    }
+  }
 
   // global is the "default" so just skip
   if (monitoredResource.type !== 'global') {

--- a/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
@@ -350,7 +350,7 @@ describe('transform', () => {
     });
   });
 
-  it('should transform matching resource attributes labels', () => {
+  it('should transform resource attributes matching resourceFilter', () => {
     const transformer = getReadableSpanTransformer('project-id', /^custom\./);
 
     const result = transformer({

--- a/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
@@ -350,6 +350,42 @@ describe('transform', () => {
     });
   });
 
+  it('should transform matching resource attributes labels', () => {
+    const transformer = getReadableSpanTransformer('project-id', /^custom\./);
+
+    const result = transformer({
+      ...readableSpan,
+      resource: new Resource({
+        'custom.foo': 'bar',
+        'custom.bool': true,
+        'custom.number': 5,
+        'not.custom.thing': 'not-custom',
+        'custom-without-a-dot': 'ignored',
+      }),
+    });
+    assert.deepStrictEqual(result.attributes, {
+      attributeMap: {
+        'custom.foo': {
+          stringValue: {
+            value: 'bar',
+          },
+        },
+        'custom.bool': {
+          boolValue: true,
+        },
+        'custom.number': {
+          intValue: '5',
+        },
+        'g.co/agent': {
+          stringValue: {
+            value: `opentelemetry-js ${CORE_VERSION}; google-cloud-trace-exporter ${VERSION}`,
+          },
+        },
+      },
+      droppedAttributesCount: 0,
+    });
+  });
+
   it('should transform span kinds', () => {
     assert.strictEqual(
       transformer({


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/347

This PR adds support for exporting OpenTelemetry resource attributes that match a regular expression, as was [suggested](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/347#issuecomment-946881138) in the linked issue.