### PR TITLE
feat: Splitting metrics CUSTOM_OPENTELEMETRY_DOMAIN from prefix

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/README.md
+++ b/packages/opentelemetry-cloud-monitoring-exporter/README.md
@@ -31,14 +31,16 @@ const meter = new MeterProvider({
 const counter = meter.createCounter('metric_name');
 counter.add(10, { [key]: 'value' });
 ```
-## Setting Custom Display Name
+## Setting Custom Display Name - Prefix
 
 ```js
 const exporter = new MetricExporter({
-  customDisplayName: 'myApplication',
+  prefix: 'myApplication',
 }
 ```
-When viewing the metric you should be able to filter on the customDisplayName value (e.g.; myApplication). 
+When viewing the metric you should be able to filter on the prefix value (e.g.; myApplication). 
+
+In addition to setting a custom prefix you can specify a custom OpenTelemetry Domain using the customOTDomain option. The default value is custom.googleapis.com/opentelemetry.
 
 ##  Viewing your metrics:
 

--- a/packages/opentelemetry-cloud-monitoring-exporter/README.md
+++ b/packages/opentelemetry-cloud-monitoring-exporter/README.md
@@ -31,6 +31,14 @@ const meter = new MeterProvider({
 const counter = meter.createCounter('metric_name');
 counter.add(10, { [key]: 'value' });
 ```
+## Setting Custom Display Name
+
+```js
+const exporter = new MetricExporter({
+  customDisplayName: 'myApplication',
+}
+```
+When viewing the metric you should be able to filter on the customDisplayName value (e.g.; myApplication). 
 
 ##  Viewing your metrics:
 

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/external-types.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/external-types.ts
@@ -36,10 +36,15 @@ export interface ExporterOptions {
    */
   credentials?: Credentials;
   /**
-   * Prefix for metric overrides the OpenTelemetry prefix
+   * Display name for metric overrides the OpenTelemetry prefix
    * of a stackdriver metric. Optional
    */
-  prefix?: string;
+  dipslayNamePrefix?: string;
+  /**
+   * Custom OpenTelemetry domain override default
+   * custom.googleapis.com/OpenTelemetry. Optional 
+   */
+   customOTDomain?: string;
 }
 
 export interface Credentials {

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/external-types.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/external-types.ts
@@ -39,12 +39,12 @@ export interface ExporterOptions {
    * Display name for metric overrides the OpenTelemetry prefix
    * of a stackdriver metric. Optional
    */
-  dipslayNamePrefix?: string;
+  displayNamePrefix?: string;
   /**
    * Custom OpenTelemetry domain override default
-   * custom.googleapis.com/OpenTelemetry. Optional 
+   * custom.googleapis.com/OpenTelemetry. Optional
    */
-   customOTDomain?: string;
+  customOTDomain?: string;
 }
 
 export interface Credentials {

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/external-types.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/external-types.ts
@@ -36,10 +36,10 @@ export interface ExporterOptions {
    */
   credentials?: Credentials;
   /**
-   * Display name for metric overrides the OpenTelemetry prefix
+   * Display name or prefix for metric overrides the OpenTelemetry prefix
    * of a stackdriver metric. Optional
    */
-  displayNamePrefix?: string;
+  prefix?: string;
   /**
    * Custom OpenTelemetry domain override default
    * custom.googleapis.com/OpenTelemetry. Optional

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
@@ -62,7 +62,7 @@ export class MetricExporter implements IMetricExporter {
     this._metricPrefix =
       options.customOTDomain || MetricExporter.CUSTOM_OPENTELEMETRY_DOMAIN;
     this._displayNamePrefix =
-      options.displayNamePrefix || MetricExporter.DEFAULT_DISPLAY_NAME_PREFIX;
+      options.prefix || MetricExporter.DEFAULT_DISPLAY_NAME_PREFIX;
 
     this._auth = new GoogleAuth({
       credentials: options.credentials,

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
@@ -60,9 +60,9 @@ export class MetricExporter implements IMetricExporter {
 
   constructor(options: ExporterOptions = {}) {
     this._metricPrefix =
-      options.prefix || MetricExporter.CUSTOM_OPENTELEMETRY_DOMAIN;
+      options.customOTDomain || MetricExporter.CUSTOM_OPENTELEMETRY_DOMAIN;
     this._displayNamePrefix =
-      options.prefix || MetricExporter.DEFAULT_DISPLAY_NAME_PREFIX;
+      options.displayNamePrefix || MetricExporter.DEFAULT_DISPLAY_NAME_PREFIX;
 
     this._auth = new GoogleAuth({
       credentials: options.credentials,


### PR DESCRIPTION
Splitting metric option prefix into displayNamePrefix and customOTDomain.

Fixes #386