### PR TITLE
Add apiEndpoint option to cloud monitoring exporter

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/src/external-types.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/external-types.ts
@@ -40,6 +40,11 @@ export interface ExporterOptions {
    * of a stackdriver metric. Optional
    */
   prefix?: string;
+  /**
+   * The api endpoint of the cloud monitoring service. Defaults to
+   * monitoring.googleapis.com:443.
+   */
+  apiEndpoint?: string;
 }
 
 export interface Credentials {

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
@@ -90,7 +90,7 @@ describe('MetricExporter', () => {
       );
 
       sinon.replace(
-        MetricExporter['_monitoring'].projects.metricDescriptors,
+        exporter['_monitoring'].projects.metricDescriptors,
         'create',
         metricDescriptors as any
       );
@@ -109,7 +109,7 @@ describe('MetricExporter', () => {
       );
 
       sinon.replace(
-        MetricExporter['_monitoring'].projects.timeSeries,
+        exporter['_monitoring'].projects.timeSeries,
         'create',
         timeSeries as any
       );


### PR DESCRIPTION
The underlying client library doesn't expose apiEndpoint like the trace one does, so I've named it differently (rootUrl instead of apiEndpoint) accordingly.