### PR TITLE
chore: increase gce integration test timeout

### DIFF
--- a/cloudbuild-e2e-gce.yaml
+++ b/cloudbuild-e2e-gce.yaml
@@ -30,7 +30,7 @@ steps:
     args:
       - gce
       - --image=$_TEST_SERVER_IMAGE
-      - --health-check-timeout=5m
+      - --health-check-timeout=8m
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m


### PR DESCRIPTION
It is timing out waiting for the container to start https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/pull/371/checks?check_run_id=8621886819

If this gets much longer, we may need to investigate. I had to increase it for operations-python repo as well, but operations-go doesn't seem to have a similar problem. It could be the docker image is too large.