### PR TITLE
chore: add renovate package group for all mocha lockstep versioned packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,10 @@
     {
       "matchPackageNames": ["typescript"],
       "groupName": "typescript"
+    },
+    {
+      "matchPackageNames": ["mocha", "ts-mocha", "@types/mocha"],
+      "groupName": "mocha"
     }
   ]
 }


### PR DESCRIPTION
This will cause renovate to group these PRs into one:
- https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/pull/401
- https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/pull/422

peerDependency which makes it impossible to upgrade separately