### PR TITLE
chore: fix renovate config typo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
       "groupName": "mocha"
     },
     {
-      "matchPackagePrefix": ["@opentelemetry/"],
+      "matchPackagePrefixes": ["@opentelemetry/"],
       "groupName": "opentelemetry upstream"
     }
   ]


### PR DESCRIPTION
This time I validated the config with `renovate_config_validator` script
