### PR TITLE
fix(monitoring-exporter): convert to GCM format based on metric data type, not instrument type

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/__snapshots__/instrument-snapshot.test.ts.js
+++ b/packages/opentelemetry-cloud-monitoring-exporter/__snapshots__/instrument-snapshot.test.ts.js
@@ -811,3 +811,95 @@ exports['MetricExporter snapshot tests UpDownCounter - INT 1'] = [
     ]
   }
 ]
+
+exports['MetricExporter snapshot tests reconfigure with views counter with histogram view 1'] = [
+  {
+    "uri": "/v3/projects/otel-starter-project/metricDescriptors",
+    "body": {
+      "type": "workload.googleapis.com/myrenamedhistogram",
+      "description": "instrument description",
+      "displayName": "myrenamedhistogram",
+      "metricKind": "CUMULATIVE",
+      "valueType": "DOUBLE",
+      "unit": "{myunit}",
+      "labels": [
+        {
+          "key": "opentelemetry_task",
+          "description": "OpenTelemetry task identifier"
+        }
+      ]
+    },
+    "userAgent": [
+      "opentelemetry-js/1.8.0 google-cloud-metric-exporter/0.14.0 google-api-nodejs-client/5.1.0 (gzip)"
+    ]
+  },
+  {
+    "uri": "/v3/projects/otel-starter-project/timeSeries",
+    "body": {
+      "timeSeries": [
+        {
+          "metric": {
+            "type": "workload.googleapis.com/myrenamedhistogram",
+            "labels": {
+              "opentelemetry_task": "opentelemetry_task"
+            }
+          },
+          "resource": {
+            "type": "global",
+            "labels": {
+              "project_id": "otel-starter-project"
+            }
+          },
+          "metricKind": "CUMULATIVE",
+          "valueType": "DOUBLE",
+          "points": [
+            {
+              "value": {
+                "distributionValue": {
+                  "count": "1",
+                  "mean": 12.3,
+                  "bucketOptions": {
+                    "explicitBuckets": {
+                      "bounds": [
+                        0,
+                        5,
+                        10,
+                        25,
+                        50,
+                        75,
+                        100,
+                        250,
+                        500,
+                        1000
+                      ]
+                    }
+                  },
+                  "bucketCounts": [
+                    "0",
+                    "0",
+                    "0",
+                    "1",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0"
+                  ]
+                }
+              },
+              "interval": {
+                "startTime": "startTime",
+                "endTime": "endTime"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "userAgent": [
+      "opentelemetry-js/1.8.0 google-cloud-metric-exporter/0.14.0 google-api-nodejs-client/5.1.0 (gzip)"
+    ]
+  }
+]

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/util.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/util.ts
@@ -14,6 +14,7 @@
 
 import {
   MeterProvider,
+  MeterProviderOptions,
   MetricReader,
   ResourceMetrics,
 } from '@opentelemetry/sdk-metrics';
@@ -27,9 +28,10 @@ class InMemoryMetricReader extends MetricReader {
 }
 
 export async function generateMetricsData(
-  customize?: (meterProvider: MeterProvider, meter: Meter) => void
+  customize?: (meterProvider: MeterProvider, meter: Meter) => void,
+  meterProviderOptions?: MeterProviderOptions
 ): Promise<ResourceMetrics> {
-  const meterProvider = new MeterProvider();
+  const meterProvider = new MeterProvider(meterProviderOptions);
   const reader = new InMemoryMetricReader();
   meterProvider.addMetricReader(reader);
   const meter = meterProvider.getMeter('test-meter');


### PR DESCRIPTION
This makes the exporter work with views (see included snapshot test), where the data point type will not match the instrument type. Otherwise the behavior of the exporter is unchanged.

Note the `InstrumentDescriptor.name` is still the only place to get the metric's name and it actually will match the name configured for output in the view. This is confusing, discussion going on in https://github.com/open-telemetry/opentelemetry-js/issues/3439