### PR TITLE
fix(monitoring-exporter)!: use workload.googleapis.com as default metric prefix

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/__snapshots__/instrument-snapshot.test.ts.js
+++ b/packages/opentelemetry-cloud-monitoring-exporter/__snapshots__/instrument-snapshot.test.ts.js
@@ -2,9 +2,9 @@ exports['MetricExporter snapshot tests Counter - DOUBLE 1'] = [
   {
     "uri": "/v3/projects/otel-starter-project/metricDescriptors",
     "body": {
-      "type": "custom.googleapis.com/opentelemetry/mycounter",
+      "type": "workload.googleapis.com/mycounter",
       "description": "counter description",
-      "displayName": "OpenTelemetry/mycounter",
+      "displayName": "mycounter",
       "metricKind": "CUMULATIVE",
       "valueType": "DOUBLE",
       "unit": "{myunit}",
@@ -25,7 +25,7 @@ exports['MetricExporter snapshot tests Counter - DOUBLE 1'] = [
       "timeSeries": [
         {
           "metric": {
-            "type": "custom.googleapis.com/opentelemetry/mycounter",
+            "type": "workload.googleapis.com/mycounter",
             "labels": {
               "string": "string",
               "int": "123",
@@ -65,9 +65,9 @@ exports['MetricExporter snapshot tests Counter - INT 1'] = [
   {
     "uri": "/v3/projects/otel-starter-project/metricDescriptors",
     "body": {
-      "type": "custom.googleapis.com/opentelemetry/mycounter",
+      "type": "workload.googleapis.com/mycounter",
       "description": "counter description",
-      "displayName": "OpenTelemetry/mycounter",
+      "displayName": "mycounter",
       "metricKind": "CUMULATIVE",
       "valueType": "INT64",
       "unit": "{myunit}",
@@ -88,7 +88,7 @@ exports['MetricExporter snapshot tests Counter - INT 1'] = [
       "timeSeries": [
         {
           "metric": {
-            "type": "custom.googleapis.com/opentelemetry/mycounter",
+            "type": "workload.googleapis.com/mycounter",
             "labels": {
               "string": "string",
               "int": "123",
@@ -128,9 +128,9 @@ exports['MetricExporter snapshot tests Histogram - DOUBLE 1'] = [
   {
     "uri": "/v3/projects/otel-starter-project/metricDescriptors",
     "body": {
-      "type": "custom.googleapis.com/opentelemetry/myhistogram",
+      "type": "workload.googleapis.com/myhistogram",
       "description": "histogram description",
-      "displayName": "OpenTelemetry/myhistogram",
+      "displayName": "myhistogram",
       "metricKind": "CUMULATIVE",
       "valueType": "DOUBLE",
       "unit": "{myunit}",
@@ -151,7 +151,7 @@ exports['MetricExporter snapshot tests Histogram - DOUBLE 1'] = [
       "timeSeries": [
         {
           "metric": {
-            "type": "custom.googleapis.com/opentelemetry/myhistogram",
+            "type": "workload.googleapis.com/myhistogram",
             "labels": {
               "string": "string",
               "int": "123",
@@ -223,9 +223,9 @@ exports['MetricExporter snapshot tests Histogram - INT 1'] = [
   {
     "uri": "/v3/projects/otel-starter-project/metricDescriptors",
     "body": {
-      "type": "custom.googleapis.com/opentelemetry/myhistogram",
+      "type": "workload.googleapis.com/myhistogram",
       "description": "histogram description",
-      "displayName": "OpenTelemetry/myhistogram",
+      "displayName": "myhistogram",
       "metricKind": "CUMULATIVE",
       "valueType": "INT64",
       "unit": "{myunit}",
@@ -246,7 +246,7 @@ exports['MetricExporter snapshot tests Histogram - INT 1'] = [
       "timeSeries": [
         {
           "metric": {
-            "type": "custom.googleapis.com/opentelemetry/myhistogram",
+            "type": "workload.googleapis.com/myhistogram",
             "labels": {
               "string": "string",
               "int": "123",
@@ -318,9 +318,9 @@ exports['MetricExporter snapshot tests ObservableCounter - DOUBLE 1'] = [
   {
     "uri": "/v3/projects/otel-starter-project/metricDescriptors",
     "body": {
-      "type": "custom.googleapis.com/opentelemetry/myobservablecounter",
+      "type": "workload.googleapis.com/myobservablecounter",
       "description": "counter description",
-      "displayName": "OpenTelemetry/myobservablecounter",
+      "displayName": "myobservablecounter",
       "metricKind": "CUMULATIVE",
       "valueType": "DOUBLE",
       "unit": "{myunit}",
@@ -341,7 +341,7 @@ exports['MetricExporter snapshot tests ObservableCounter - DOUBLE 1'] = [
       "timeSeries": [
         {
           "metric": {
-            "type": "custom.googleapis.com/opentelemetry/myobservablecounter",
+            "type": "workload.googleapis.com/myobservablecounter",
             "labels": {
               "string": "string",
               "int": "123",
@@ -381,9 +381,9 @@ exports['MetricExporter snapshot tests ObservableCounter - INT 1'] = [
   {
     "uri": "/v3/projects/otel-starter-project/metricDescriptors",
     "body": {
-      "type": "custom.googleapis.com/opentelemetry/myobservablecounter",
+      "type": "workload.googleapis.com/myobservablecounter",
       "description": "counter description",
-      "displayName": "OpenTelemetry/myobservablecounter",
+      "displayName": "myobservablecounter",
       "metricKind": "CUMULATIVE",
       "valueType": "INT64",
       "unit": "{myunit}",
@@ -404,7 +404,7 @@ exports['MetricExporter snapshot tests ObservableCounter - INT 1'] = [
       "timeSeries": [
         {
           "metric": {
-            "type": "custom.googleapis.com/opentelemetry/myobservablecounter",
+            "type": "workload.googleapis.com/myobservablecounter",
             "labels": {
               "string": "string",
               "int": "123",
@@ -444,9 +444,9 @@ exports['MetricExporter snapshot tests ObservableGauge - DOUBLE 1'] = [
   {
     "uri": "/v3/projects/otel-starter-project/metricDescriptors",
     "body": {
-      "type": "custom.googleapis.com/opentelemetry/myobservablegauge",
+      "type": "workload.googleapis.com/myobservablegauge",
       "description": "instrument description",
-      "displayName": "OpenTelemetry/myobservablegauge",
+      "displayName": "myobservablegauge",
       "metricKind": "GAUGE",
       "valueType": "DOUBLE",
       "unit": "{myunit}",
@@ -467,7 +467,7 @@ exports['MetricExporter snapshot tests ObservableGauge - DOUBLE 1'] = [
       "timeSeries": [
         {
           "metric": {
-            "type": "custom.googleapis.com/opentelemetry/myobservablegauge",
+            "type": "workload.googleapis.com/myobservablegauge",
             "labels": {
               "string": "string",
               "int": "123",
@@ -506,9 +506,9 @@ exports['MetricExporter snapshot tests ObservableGauge - INT 1'] = [
   {
     "uri": "/v3/projects/otel-starter-project/metricDescriptors",
     "body": {
-      "type": "custom.googleapis.com/opentelemetry/myobservablegauge",
+      "type": "workload.googleapis.com/myobservablegauge",
       "description": "instrument description",
-      "displayName": "OpenTelemetry/myobservablegauge",
+      "displayName": "myobservablegauge",
       "metricKind": "GAUGE",
       "valueType": "INT64",
       "unit": "{myunit}",
@@ -529,7 +529,7 @@ exports['MetricExporter snapshot tests ObservableGauge - INT 1'] = [
       "timeSeries": [
         {
           "metric": {
-            "type": "custom.googleapis.com/opentelemetry/myobservablegauge",
+            "type": "workload.googleapis.com/myobservablegauge",
             "labels": {
               "string": "string",
               "int": "123",
@@ -568,9 +568,9 @@ exports['MetricExporter snapshot tests ObservableUpDownCounter - DOUBLE 1'] = [
   {
     "uri": "/v3/projects/otel-starter-project/metricDescriptors",
     "body": {
-      "type": "custom.googleapis.com/opentelemetry/myobservableupdowncounter",
+      "type": "workload.googleapis.com/myobservableupdowncounter",
       "description": "instrument description",
-      "displayName": "OpenTelemetry/myobservableupdowncounter",
+      "displayName": "myobservableupdowncounter",
       "metricKind": "GAUGE",
       "valueType": "DOUBLE",
       "unit": "{myunit}",
@@ -591,7 +591,7 @@ exports['MetricExporter snapshot tests ObservableUpDownCounter - DOUBLE 1'] = [
       "timeSeries": [
         {
           "metric": {
-            "type": "custom.googleapis.com/opentelemetry/myobservableupdowncounter",
+            "type": "workload.googleapis.com/myobservableupdowncounter",
             "labels": {
               "string": "string",
               "int": "123",
@@ -630,9 +630,9 @@ exports['MetricExporter snapshot tests ObservableUpDownCounter - INT 1'] = [
   {
     "uri": "/v3/projects/otel-starter-project/metricDescriptors",
     "body": {
-      "type": "custom.googleapis.com/opentelemetry/myobservableupdowncounter",
+      "type": "workload.googleapis.com/myobservableupdowncounter",
       "description": "instrument description",
-      "displayName": "OpenTelemetry/myobservableupdowncounter",
+      "displayName": "myobservableupdowncounter",
       "metricKind": "GAUGE",
       "valueType": "INT64",
       "unit": "{myunit}",
@@ -653,7 +653,7 @@ exports['MetricExporter snapshot tests ObservableUpDownCounter - INT 1'] = [
       "timeSeries": [
         {
           "metric": {
-            "type": "custom.googleapis.com/opentelemetry/myobservableupdowncounter",
+            "type": "workload.googleapis.com/myobservableupdowncounter",
             "labels": {
               "string": "string",
               "int": "123",
@@ -692,9 +692,9 @@ exports['MetricExporter snapshot tests UpDownCounter - DOUBLE 1'] = [
   {
     "uri": "/v3/projects/otel-starter-project/metricDescriptors",
     "body": {
-      "type": "custom.googleapis.com/opentelemetry/myupdowncounter",
+      "type": "workload.googleapis.com/myupdowncounter",
       "description": "updowncounter description",
-      "displayName": "OpenTelemetry/myupdowncounter",
+      "displayName": "myupdowncounter",
       "metricKind": "GAUGE",
       "valueType": "DOUBLE",
       "unit": "{myunit}",
@@ -715,7 +715,7 @@ exports['MetricExporter snapshot tests UpDownCounter - DOUBLE 1'] = [
       "timeSeries": [
         {
           "metric": {
-            "type": "custom.googleapis.com/opentelemetry/myupdowncounter",
+            "type": "workload.googleapis.com/myupdowncounter",
             "labels": {
               "string": "string",
               "int": "123",
@@ -754,9 +754,9 @@ exports['MetricExporter snapshot tests UpDownCounter - INT 1'] = [
   {
     "uri": "/v3/projects/otel-starter-project/metricDescriptors",
     "body": {
-      "type": "custom.googleapis.com/opentelemetry/myupdowncounter",
+      "type": "workload.googleapis.com/myupdowncounter",
       "description": "updowncounter description",
-      "displayName": "OpenTelemetry/myupdowncounter",
+      "displayName": "myupdowncounter",
       "metricKind": "GAUGE",
       "valueType": "INT64",
       "unit": "{myunit}",
@@ -777,7 +777,7 @@ exports['MetricExporter snapshot tests UpDownCounter - INT 1'] = [
       "timeSeries": [
         {
           "metric": {
-            "type": "custom.googleapis.com/opentelemetry/myupdowncounter",
+            "type": "workload.googleapis.com/myupdowncounter",
             "labels": {
               "string": "string",
               "int": "123",

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/external-types.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/external-types.ts
@@ -36,8 +36,10 @@ export interface ExporterOptions {
    */
   credentials?: Credentials;
   /**
-   * Prefix for metric overrides the OpenTelemetry prefix
-   * of a stackdriver metric. Optional
+   * Prefix prepended to OpenTelemetry metric names when writing to Cloud Monitoring. See
+   * https://cloud.google.com/monitoring/custom-metrics#identifier for more details.
+   *
+   * Optional, default is `workload.googleapis.com`.
    */
   prefix?: string;
   /**

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
@@ -61,13 +61,10 @@ google.options({
 export class MetricExporter implements PushMetricExporter {
   private _projectId: string | void | Promise<string | void>;
   private readonly _metricPrefix: string;
-  private readonly _displayNamePrefix: string;
   private readonly _auth: GoogleAuth;
   private readonly _startTime = new Date().toISOString();
 
-  static readonly DEFAULT_DISPLAY_NAME_PREFIX: string = 'OpenTelemetry';
-  static readonly CUSTOM_OPENTELEMETRY_DOMAIN: string =
-    'custom.googleapis.com/opentelemetry';
+  static readonly DEFAULT_METRIC_PREFIX: string = 'workload.googleapis.com';
 
   private registeredInstrumentDescriptors: Map<string, InstrumentDescriptor> =
     new Map();
@@ -75,10 +72,7 @@ export class MetricExporter implements PushMetricExporter {
   private _monitoring: monitoring_v3.Monitoring;
 
   constructor(options: ExporterOptions = {}) {
-    this._metricPrefix =
-      options.prefix || MetricExporter.CUSTOM_OPENTELEMETRY_DOMAIN;
-    this._displayNamePrefix =
-      options.prefix || MetricExporter.DEFAULT_DISPLAY_NAME_PREFIX;
+    this._metricPrefix = options.prefix ?? MetricExporter.DEFAULT_METRIC_PREFIX;
 
     this._auth = new GoogleAuth({
       credentials: options.credentials,
@@ -232,8 +226,7 @@ export class MetricExporter implements PushMetricExporter {
     const authClient = await this._authorize();
     const descriptor = transformMetricDescriptor(
       instrumentDescriptor,
-      this._metricPrefix,
-      this._displayNamePrefix
+      this._metricPrefix
     );
     try {
       await this._monitoring.projects.metricDescriptors.create({

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -41,16 +41,12 @@ export const OPENTELEMETRY_TASK_VALUE_DEFAULT = generateDefaultTaskValue();
 
 export function transformMetricDescriptor(
   instrumentDescriptor: InstrumentDescriptor,
-  metricPrefix: string,
-  displayNamePrefix: string
+  metricPrefix: string
 ): MetricDescriptor {
   return {
     type: transformMetricType(metricPrefix, instrumentDescriptor.name),
     description: instrumentDescriptor.description,
-    displayName: transformDisplayName(
-      displayNamePrefix,
-      instrumentDescriptor.name
-    ),
+    displayName: instrumentDescriptor.name,
     metricKind: transformMetricKind(instrumentDescriptor.type),
     valueType: transformValueType(instrumentDescriptor.valueType),
     unit: instrumentDescriptor.unit,
@@ -66,11 +62,6 @@ export function transformMetricDescriptor(
 /** Transforms Metric type. */
 function transformMetricType(metricPrefix: string, name: string): string {
   return path.posix.join(metricPrefix, name);
-}
-
-/** Transforms Metric display name. */
-function transformDisplayName(displayNamePrefix: string, name: string): string {
-  return path.posix.join(displayNamePrefix, name);
 }
 
 /** Transforms a OpenTelemetry instrument type to a GCM MetricKind. */
@@ -231,13 +222,3 @@ function generateDefaultTaskValue(): string {
 function exhaust(switchValue: never) {
   return switchValue;
 }
-
-export const TEST_ONLY = {
-  transformMetricKind,
-  transformValueType,
-  transformDisplayName,
-  transformMetricType,
-  transformMetric,
-  transformPoints,
-  OPENTELEMETRY_TASK,
-};

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
@@ -174,7 +174,7 @@ describe('MetricExporter', () => {
       assert.deepStrictEqual(result, {code: ExportResultCode.SUCCESS});
       assert.deepStrictEqual(
         metricDescriptors.getCall(0).args[0].requestBody!.type,
-        'custom.googleapis.com/opentelemetry/name'
+        'workload.googleapis.com/name'
       );
 
       assert.strictEqual(metricDescriptors.callCount, 1);
@@ -193,7 +193,7 @@ describe('MetricExporter', () => {
 
       assert.deepStrictEqual(
         metricDescriptors.getCall(0).args[0].requestBody!.type,
-        'custom.googleapis.com/opentelemetry/name'
+        'workload.googleapis.com/name'
       );
       assert.strictEqual(metricDescriptors.callCount, 1);
       assert.strictEqual(timeSeries.callCount, 1);
@@ -219,15 +219,15 @@ describe('MetricExporter', () => {
 
       assert.deepStrictEqual(
         metricDescriptors.getCall(0).args[0].requestBody!.type,
-        'custom.googleapis.com/opentelemetry/name400'
+        'workload.googleapis.com/name400'
       );
       assert.deepStrictEqual(
         metricDescriptors.getCall(100).args[0].requestBody!.type,
-        'custom.googleapis.com/opentelemetry/name300'
+        'workload.googleapis.com/name300'
       );
       assert.deepStrictEqual(
         metricDescriptors.getCall(400).args[0].requestBody!.type,
-        'custom.googleapis.com/opentelemetry/name0'
+        'workload.googleapis.com/name0'
       );
 
       assert.strictEqual(metricDescriptors.callCount, 401);


### PR DESCRIPTION
Also removed the display name prefix. The OTel metric name without the
GCM metric prefix is now used for display name.

Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/386