### PR TITLE
fix(monitoring-exporter)!: remove auto generated task ID label from metrics

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/__snapshots__/instrument-snapshot.test.ts.js
+++ b/packages/opentelemetry-cloud-monitoring-exporter/__snapshots__/instrument-snapshot.test.ts.js
@@ -8,12 +8,7 @@ exports['MetricExporter snapshot tests Counter - DOUBLE 1'] = [
       "metricKind": "CUMULATIVE",
       "valueType": "DOUBLE",
       "unit": "{myunit}",
-      "labels": [
-        {
-          "key": "opentelemetry_task",
-          "description": "OpenTelemetry task identifier"
-        }
-      ]
+      "labels": []
     },
     "userAgent": [
       "opentelemetry-js/1.8.0 google-cloud-metric-exporter/0.14.0 google-api-nodejs-client/5.1.0 (gzip)"
@@ -29,8 +24,7 @@ exports['MetricExporter snapshot tests Counter - DOUBLE 1'] = [
             "labels": {
               "string": "string",
               "int": "123",
-              "float": "123.4",
-              "opentelemetry_task": "opentelemetry_task"
+              "float": "123.4"
             }
           },
           "resource": {
@@ -71,12 +65,7 @@ exports['MetricExporter snapshot tests Counter - INT 1'] = [
       "metricKind": "CUMULATIVE",
       "valueType": "INT64",
       "unit": "{myunit}",
-      "labels": [
-        {
-          "key": "opentelemetry_task",
-          "description": "OpenTelemetry task identifier"
-        }
-      ]
+      "labels": []
     },
     "userAgent": [
       "opentelemetry-js/1.8.0 google-cloud-metric-exporter/0.14.0 google-api-nodejs-client/5.1.0 (gzip)"
@@ -92,8 +81,7 @@ exports['MetricExporter snapshot tests Counter - INT 1'] = [
             "labels": {
               "string": "string",
               "int": "123",
-              "float": "123.4",
-              "opentelemetry_task": "opentelemetry_task"
+              "float": "123.4"
             }
           },
           "resource": {
@@ -134,12 +122,7 @@ exports['MetricExporter snapshot tests Histogram - DOUBLE 1'] = [
       "metricKind": "CUMULATIVE",
       "valueType": "DOUBLE",
       "unit": "{myunit}",
-      "labels": [
-        {
-          "key": "opentelemetry_task",
-          "description": "OpenTelemetry task identifier"
-        }
-      ]
+      "labels": []
     },
     "userAgent": [
       "opentelemetry-js/1.8.0 google-cloud-metric-exporter/0.14.0 google-api-nodejs-client/5.1.0 (gzip)"
@@ -155,8 +138,7 @@ exports['MetricExporter snapshot tests Histogram - DOUBLE 1'] = [
             "labels": {
               "string": "string",
               "int": "123",
-              "float": "123.4",
-              "opentelemetry_task": "opentelemetry_task"
+              "float": "123.4"
             }
           },
           "resource": {
@@ -229,12 +211,7 @@ exports['MetricExporter snapshot tests Histogram - INT 1'] = [
       "metricKind": "CUMULATIVE",
       "valueType": "INT64",
       "unit": "{myunit}",
-      "labels": [
-        {
-          "key": "opentelemetry_task",
-          "description": "OpenTelemetry task identifier"
-        }
-      ]
+      "labels": []
     },
     "userAgent": [
       "opentelemetry-js/1.8.0 google-cloud-metric-exporter/0.14.0 google-api-nodejs-client/5.1.0 (gzip)"
@@ -250,8 +227,7 @@ exports['MetricExporter snapshot tests Histogram - INT 1'] = [
             "labels": {
               "string": "string",
               "int": "123",
-              "float": "123.4",
-              "opentelemetry_task": "opentelemetry_task"
+              "float": "123.4"
             }
           },
           "resource": {
@@ -324,12 +300,7 @@ exports['MetricExporter snapshot tests ObservableCounter - DOUBLE 1'] = [
       "metricKind": "CUMULATIVE",
       "valueType": "DOUBLE",
       "unit": "{myunit}",
-      "labels": [
-        {
-          "key": "opentelemetry_task",
-          "description": "OpenTelemetry task identifier"
-        }
-      ]
+      "labels": []
     },
     "userAgent": [
       "opentelemetry-js/1.8.0 google-cloud-metric-exporter/0.14.0 google-api-nodejs-client/5.1.0 (gzip)"
@@ -345,8 +316,7 @@ exports['MetricExporter snapshot tests ObservableCounter - DOUBLE 1'] = [
             "labels": {
               "string": "string",
               "int": "123",
-              "float": "123.4",
-              "opentelemetry_task": "opentelemetry_task"
+              "float": "123.4"
             }
           },
           "resource": {
@@ -387,12 +357,7 @@ exports['MetricExporter snapshot tests ObservableCounter - INT 1'] = [
       "metricKind": "CUMULATIVE",
       "valueType": "INT64",
       "unit": "{myunit}",
-      "labels": [
-        {
-          "key": "opentelemetry_task",
-          "description": "OpenTelemetry task identifier"
-        }
-      ]
+      "labels": []
     },
     "userAgent": [
       "opentelemetry-js/1.8.0 google-cloud-metric-exporter/0.14.0 google-api-nodejs-client/5.1.0 (gzip)"
@@ -408,8 +373,7 @@ exports['MetricExporter snapshot tests ObservableCounter - INT 1'] = [
             "labels": {
               "string": "string",
               "int": "123",
-              "float": "123.4",
-              "opentelemetry_task": "opentelemetry_task"
+              "float": "123.4"
             }
           },
           "resource": {
@@ -450,12 +414,7 @@ exports['MetricExporter snapshot tests ObservableGauge - DOUBLE 1'] = [
       "metricKind": "GAUGE",
       "valueType": "DOUBLE",
       "unit": "{myunit}",
-      "labels": [
-        {
-          "key": "opentelemetry_task",
-          "description": "OpenTelemetry task identifier"
-        }
-      ]
+      "labels": []
     },
     "userAgent": [
       "opentelemetry-js/1.8.0 google-cloud-metric-exporter/0.14.0 google-api-nodejs-client/5.1.0 (gzip)"
@@ -471,8 +430,7 @@ exports['MetricExporter snapshot tests ObservableGauge - DOUBLE 1'] = [
             "labels": {
               "string": "string",
               "int": "123",
-              "float": "123.4",
-              "opentelemetry_task": "opentelemetry_task"
+              "float": "123.4"
             }
           },
           "resource": {
@@ -512,12 +470,7 @@ exports['MetricExporter snapshot tests ObservableGauge - INT 1'] = [
       "metricKind": "GAUGE",
       "valueType": "INT64",
       "unit": "{myunit}",
-      "labels": [
-        {
-          "key": "opentelemetry_task",
-          "description": "OpenTelemetry task identifier"
-        }
-      ]
+      "labels": []
     },
     "userAgent": [
       "opentelemetry-js/1.8.0 google-cloud-metric-exporter/0.14.0 google-api-nodejs-client/5.1.0 (gzip)"
@@ -533,8 +486,7 @@ exports['MetricExporter snapshot tests ObservableGauge - INT 1'] = [
             "labels": {
               "string": "string",
               "int": "123",
-              "float": "123.4",
-              "opentelemetry_task": "opentelemetry_task"
+              "float": "123.4"
             }
           },
           "resource": {
@@ -574,12 +526,7 @@ exports['MetricExporter snapshot tests ObservableUpDownCounter - DOUBLE 1'] = [
       "metricKind": "GAUGE",
       "valueType": "DOUBLE",
       "unit": "{myunit}",
-      "labels": [
-        {
-          "key": "opentelemetry_task",
-          "description": "OpenTelemetry task identifier"
-        }
-      ]
+      "labels": []
     },
     "userAgent": [
       "opentelemetry-js/1.8.0 google-cloud-metric-exporter/0.14.0 google-api-nodejs-client/5.1.0 (gzip)"
@@ -595,8 +542,7 @@ exports['MetricExporter snapshot tests ObservableUpDownCounter - DOUBLE 1'] = [
             "labels": {
               "string": "string",
               "int": "123",
-              "float": "123.4",
-              "opentelemetry_task": "opentelemetry_task"
+              "float": "123.4"
             }
           },
           "resource": {
@@ -636,12 +582,7 @@ exports['MetricExporter snapshot tests ObservableUpDownCounter - INT 1'] = [
       "metricKind": "GAUGE",
       "valueType": "INT64",
       "unit": "{myunit}",
-      "labels": [
-        {
-          "key": "opentelemetry_task",
-          "description": "OpenTelemetry task identifier"
-        }
-      ]
+      "labels": []
     },
     "userAgent": [
       "opentelemetry-js/1.8.0 google-cloud-metric-exporter/0.14.0 google-api-nodejs-client/5.1.0 (gzip)"
@@ -657,8 +598,7 @@ exports['MetricExporter snapshot tests ObservableUpDownCounter - INT 1'] = [
             "labels": {
               "string": "string",
               "int": "123",
-              "float": "123.4",
-              "opentelemetry_task": "opentelemetry_task"
+              "float": "123.4"
             }
           },
           "resource": {
@@ -698,12 +638,7 @@ exports['MetricExporter snapshot tests UpDownCounter - DOUBLE 1'] = [
       "metricKind": "GAUGE",
       "valueType": "DOUBLE",
       "unit": "{myunit}",
-      "labels": [
-        {
-          "key": "opentelemetry_task",
-          "description": "OpenTelemetry task identifier"
-        }
-      ]
+      "labels": []
     },
     "userAgent": [
       "opentelemetry-js/1.8.0 google-cloud-metric-exporter/0.14.0 google-api-nodejs-client/5.1.0 (gzip)"
@@ -719,8 +654,7 @@ exports['MetricExporter snapshot tests UpDownCounter - DOUBLE 1'] = [
             "labels": {
               "string": "string",
               "int": "123",
-              "float": "123.4",
-              "opentelemetry_task": "opentelemetry_task"
+              "float": "123.4"
             }
           },
           "resource": {
@@ -760,12 +694,7 @@ exports['MetricExporter snapshot tests UpDownCounter - INT 1'] = [
       "metricKind": "GAUGE",
       "valueType": "INT64",
       "unit": "{myunit}",
-      "labels": [
-        {
-          "key": "opentelemetry_task",
-          "description": "OpenTelemetry task identifier"
-        }
-      ]
+      "labels": []
     },
     "userAgent": [
       "opentelemetry-js/1.8.0 google-cloud-metric-exporter/0.14.0 google-api-nodejs-client/5.1.0 (gzip)"
@@ -781,8 +710,7 @@ exports['MetricExporter snapshot tests UpDownCounter - INT 1'] = [
             "labels": {
               "string": "string",
               "int": "123",
-              "float": "123.4",
-              "opentelemetry_task": "opentelemetry_task"
+              "float": "123.4"
             }
           },
           "resource": {
@@ -822,12 +750,7 @@ exports['MetricExporter snapshot tests reconfigure with views counter with histo
       "metricKind": "CUMULATIVE",
       "valueType": "DOUBLE",
       "unit": "{myunit}",
-      "labels": [
-        {
-          "key": "opentelemetry_task",
-          "description": "OpenTelemetry task identifier"
-        }
-      ]
+      "labels": []
     },
     "userAgent": [
       "opentelemetry-js/1.8.0 google-cloud-metric-exporter/0.14.0 google-api-nodejs-client/5.1.0 (gzip)"
@@ -840,9 +763,7 @@ exports['MetricExporter snapshot tests reconfigure with views counter with histo
         {
           "metric": {
             "type": "workload.googleapis.com/myrenamedhistogram",
-            "labels": {
-              "opentelemetry_task": "opentelemetry_task"
-            }
+            "labels": {}
           },
           "resource": {
             "type": "global",

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -30,13 +30,8 @@ import {
   ValueType,
 } from './types';
 import * as path from 'path';
-import * as os from 'os';
 import type {monitoring_v3} from 'googleapis';
 import {PreciseDate} from '@google-cloud/precise-date';
-
-const OPENTELEMETRY_TASK = 'opentelemetry_task';
-const OPENTELEMETRY_TASK_DESCRIPTION = 'OpenTelemetry task identifier';
-export const OPENTELEMETRY_TASK_VALUE_DEFAULT = generateDefaultTaskValue();
 
 /**
  *
@@ -60,12 +55,7 @@ export function transformMetricDescriptor(
     metricKind: transformMetricKind(metric),
     valueType: transformValueType(metric),
     unit,
-    labels: [
-      {
-        key: OPENTELEMETRY_TASK,
-        description: OPENTELEMETRY_TASK_DESCRIPTION,
-      },
-    ],
+    labels: [],
   };
 }
 
@@ -139,7 +129,6 @@ function transformMetric<T>(
   Object.keys(point.attributes).forEach(
     key => (labels[key] = `${point.attributes[key]}`)
   );
-  labels[OPENTELEMETRY_TASK] = OPENTELEMETRY_TASK_VALUE_DEFAULT;
   return {type, labels};
 }
 
@@ -221,13 +210,6 @@ function transformHistogramValue(
       bucketCounts: value.buckets.counts.map(count => count.toString()),
     },
   };
-}
-
-/** Returns a task label value in the format of 'nodejs-<pid>@<hostname>'. */
-function generateDefaultTaskValue(): string {
-  const pid = process.pid;
-  const hostname = os.hostname() || 'localhost';
-  return 'nodejs-' + pid + '@' + hostname;
 }
 
 /**

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/instrument-snapshot.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/instrument-snapshot.test.ts
@@ -86,11 +86,6 @@ class GcmNock {
     this.calls.forEach(call => {
       if ('timeSeries' in call.body) {
         call.body.timeSeries?.forEach(ts => {
-          // Sanitize the opentelemetry_task per-process label that will change every time
-          if (ts.metric?.labels?.opentelemetry_task) {
-            ts.metric.labels.opentelemetry_task = 'opentelemetry_task';
-          }
-
           ts.points?.forEach(point => {
             // Sanitize start and end times
             if (point.interval?.startTime) {


### PR DESCRIPTION
This feature creates high cardinality by default. If users want this feature, they should set `service.*` resource labels to create a globally unique triple as described [in the spec](https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/#service:~:text=%5B3%5D%3A%20MUST%20be%20unique%20for%20each%20instance%20of%20the%20same%20service.namespace%2Cservice.name%20pair%20(in%20other%20words%20service.namespace%2Cservice.name%2Cservice.instance.id%20triplet%20MUST%20be%20globally%20unique)).

This will be possible once https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/459 is fixed.