### PR TITLE
feat: implement resource mapping for all supporter monitored resource types

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/__snapshots__/instrument-snapshot.test.ts.js
+++ b/packages/opentelemetry-cloud-monitoring-exporter/__snapshots__/instrument-snapshot.test.ts.js
@@ -28,9 +28,11 @@ exports['MetricExporter snapshot tests Counter - DOUBLE 1'] = [
             }
           },
           "resource": {
-            "type": "global",
+            "type": "generic_node",
             "labels": {
-              "project_id": "otel-starter-project"
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
             }
           },
           "metricKind": "CUMULATIVE",
@@ -85,9 +87,11 @@ exports['MetricExporter snapshot tests Counter - INT 1'] = [
             }
           },
           "resource": {
-            "type": "global",
+            "type": "generic_node",
             "labels": {
-              "project_id": "otel-starter-project"
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
             }
           },
           "metricKind": "CUMULATIVE",
@@ -142,9 +146,11 @@ exports['MetricExporter snapshot tests Histogram - DOUBLE 1'] = [
             }
           },
           "resource": {
-            "type": "global",
+            "type": "generic_node",
             "labels": {
-              "project_id": "otel-starter-project"
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
             }
           },
           "metricKind": "CUMULATIVE",
@@ -231,9 +237,11 @@ exports['MetricExporter snapshot tests Histogram - INT 1'] = [
             }
           },
           "resource": {
-            "type": "global",
+            "type": "generic_node",
             "labels": {
-              "project_id": "otel-starter-project"
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
             }
           },
           "metricKind": "CUMULATIVE",
@@ -320,9 +328,11 @@ exports['MetricExporter snapshot tests ObservableCounter - DOUBLE 1'] = [
             }
           },
           "resource": {
-            "type": "global",
+            "type": "generic_node",
             "labels": {
-              "project_id": "otel-starter-project"
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
             }
           },
           "metricKind": "CUMULATIVE",
@@ -377,9 +387,11 @@ exports['MetricExporter snapshot tests ObservableCounter - INT 1'] = [
             }
           },
           "resource": {
-            "type": "global",
+            "type": "generic_node",
             "labels": {
-              "project_id": "otel-starter-project"
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
             }
           },
           "metricKind": "CUMULATIVE",
@@ -434,9 +446,11 @@ exports['MetricExporter snapshot tests ObservableGauge - DOUBLE 1'] = [
             }
           },
           "resource": {
-            "type": "global",
+            "type": "generic_node",
             "labels": {
-              "project_id": "otel-starter-project"
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
             }
           },
           "metricKind": "GAUGE",
@@ -490,9 +504,11 @@ exports['MetricExporter snapshot tests ObservableGauge - INT 1'] = [
             }
           },
           "resource": {
-            "type": "global",
+            "type": "generic_node",
             "labels": {
-              "project_id": "otel-starter-project"
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
             }
           },
           "metricKind": "GAUGE",
@@ -546,9 +562,11 @@ exports['MetricExporter snapshot tests ObservableUpDownCounter - DOUBLE 1'] = [
             }
           },
           "resource": {
-            "type": "global",
+            "type": "generic_node",
             "labels": {
-              "project_id": "otel-starter-project"
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
             }
           },
           "metricKind": "GAUGE",
@@ -602,9 +620,11 @@ exports['MetricExporter snapshot tests ObservableUpDownCounter - INT 1'] = [
             }
           },
           "resource": {
-            "type": "global",
+            "type": "generic_node",
             "labels": {
-              "project_id": "otel-starter-project"
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
             }
           },
           "metricKind": "GAUGE",
@@ -658,9 +678,11 @@ exports['MetricExporter snapshot tests UpDownCounter - DOUBLE 1'] = [
             }
           },
           "resource": {
-            "type": "global",
+            "type": "generic_node",
             "labels": {
-              "project_id": "otel-starter-project"
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
             }
           },
           "metricKind": "GAUGE",
@@ -714,9 +736,11 @@ exports['MetricExporter snapshot tests UpDownCounter - INT 1'] = [
             }
           },
           "resource": {
-            "type": "global",
+            "type": "generic_node",
             "labels": {
-              "project_id": "otel-starter-project"
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
             }
           },
           "metricKind": "GAUGE",
@@ -766,9 +790,11 @@ exports['MetricExporter snapshot tests reconfigure with views counter with histo
             "labels": {}
           },
           "resource": {
-            "type": "global",
+            "type": "generic_node",
             "labels": {
-              "project_id": "otel-starter-project"
+              "location": "global",
+              "namespace": "",
+              "node_id": ""
             }
           },
           "metricKind": "CUMULATIVE",

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
@@ -140,8 +140,7 @@ export class MetricExporter implements PushMetricExporter {
 
     diag.debug('Google Cloud Monitoring export');
     const resource = mapOtelResourceToMonitoredResource(
-      resourceMetrics.resource,
-      this._projectId
+      resourceMetrics.resource
     );
     const timeSeries: TimeSeries[] = [];
     for (const scopeMetric of resourceMetrics.scopeMetrics) {

--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -205,10 +205,7 @@ function transformResourceToAttributes(
   resourceFilter?: RegExp,
   stringifyArrayAttributes?: boolean
 ): Attributes {
-  const monitoredResource = mapOtelResourceToMonitoredResource(
-    resource,
-    projectId
-  );
+  const monitoredResource = mapOtelResourceToMonitoredResource(resource);
   const attributes: ot.SpanAttributes = {};
 
   if (resourceFilter) {

--- a/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
@@ -67,6 +67,21 @@ describe('transform', () => {
               value: `opentelemetry-js ${CORE_VERSION}; google-cloud-trace-exporter ${VERSION}`,
             },
           },
+          'g.co/r/generic_node/location': {
+            stringValue: {
+              value: 'global',
+            },
+          },
+          'g.co/r/generic_node/namespace': {
+            stringValue: {
+              value: '',
+            },
+          },
+          'g.co/r/generic_node/node_id': {
+            stringValue: {
+              value: '',
+            },
+          },
         },
         droppedAttributesCount: 0,
       },
@@ -196,9 +211,9 @@ describe('transform', () => {
     // @ts-expect-error testing behavior with unsupported type
     readableSpan.attributes.testUnknownType = {message: 'dropped'};
     const result = transformer(readableSpan);
-    // count of 1 for just the g.co/agent attribute
     assert.deepStrictEqual(result.attributes!.droppedAttributesCount, 1);
-    assert.strictEqual(Object.keys(result.attributes!.attributeMap!).length, 1);
+    // count of 4 for the g.co/agent attribute + three g.co/r/generic_node/{label} labels
+    assert.strictEqual(Object.keys(result.attributes!.attributeMap!).length, 4);
   });
 
   it('should transform links', () => {
@@ -366,6 +381,7 @@ describe('transform', () => {
       ...readableSpan,
       resource: new Resource({
         'cloud.provider': 'gcp',
+        'cloud.platform': 'gcp_compute_engine',
         'host.id': 'foobar.com',
         'cloud.availability_zone': 'us-west1-a',
       }),
@@ -380,11 +396,6 @@ describe('transform', () => {
         'g.co/r/gce_instance/instance_id': {
           stringValue: {
             value: 'foobar.com',
-          },
-        },
-        'g.co/r/gce_instance/project_id': {
-          stringValue: {
-            value: 'project-id',
           },
         },
         'g.co/r/gce_instance/zone': {
@@ -426,6 +437,21 @@ describe('transform', () => {
         'g.co/agent': {
           stringValue: {
             value: `opentelemetry-js ${CORE_VERSION}; google-cloud-trace-exporter ${VERSION}`,
+          },
+        },
+        'g.co/r/generic_node/location': {
+          stringValue: {
+            value: 'global',
+          },
+        },
+        'g.co/r/generic_node/namespace': {
+          stringValue: {
+            value: '',
+          },
+        },
+        'g.co/r/generic_node/node_id': {
+          stringValue: {
+            value: '',
           },
         },
       },

--- a/packages/opentelemetry-resource-util/.eslintignore
+++ b/packages/opentelemetry-resource-util/.eslintignore
@@ -1,1 +1,2 @@
 build/
+__snapshots__

--- a/packages/opentelemetry-resource-util/__snapshots__/index.test.ts.js
+++ b/packages/opentelemetry-resource-util/__snapshots__/index.test.ts.js
@@ -1,0 +1,176 @@
+exports['mapOtelResourceToMonitoredResource should map empty resource to generic_node 1'] = {
+  "type": "generic_node",
+  "labels": {
+    "location": "global",
+    "namespace": "",
+    "node_id": ""
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to aws_ec2_instance with region fallback 1'] = {
+  "type": "aws_ec2_instance",
+  "labels": {
+    "instance_id": "myhostid",
+    "region": "myregion",
+    "aws_account": "myawsaccount"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to aws_ec2_instance" 1'] = {
+  "type": "aws_ec2_instance",
+  "labels": {
+    "instance_id": "myhostid",
+    "region": "myavailzone",
+    "aws_account": "myawsaccount"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to gce_instance 1'] = {
+  "type": "gce_instance",
+  "labels": {
+    "zone": "foo",
+    "instance_id": "myhost"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to generic_node 1'] = {
+  "type": "generic_node",
+  "labels": {
+    "location": "myavailzone",
+    "namespace": "servicens",
+    "node_id": "hostid"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to generic_node fallback to region 1'] = {
+  "type": "generic_node",
+  "labels": {
+    "location": "myregion",
+    "namespace": "servicens",
+    "node_id": "hostid"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to generic_node with fallback to global 1'] = {
+  "type": "generic_node",
+  "labels": {
+    "location": "global",
+    "namespace": "servicens",
+    "node_id": "hostid"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to generic_node with fallback to host.name 1'] = {
+  "type": "generic_node",
+  "labels": {
+    "location": "global",
+    "namespace": "servicens",
+    "node_id": "hostname"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to generic_task 1'] = {
+  "type": "generic_task",
+  "labels": {
+    "location": "myavailzone",
+    "namespace": "servicens",
+    "job": "servicename",
+    "task_id": "serviceinstanceid"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to generic_task with fallback to global 1'] = {
+  "type": "generic_task",
+  "labels": {
+    "location": "global",
+    "namespace": "servicens",
+    "job": "servicename",
+    "task_id": "serviceinstanceid"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to generic_task with fallback to region 1'] = {
+  "type": "generic_task",
+  "labels": {
+    "location": "myregion",
+    "namespace": "servicens",
+    "job": "servicename",
+    "task_id": "serviceinstanceid"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to k8s_cluster 1'] = {
+  "type": "k8s_cluster",
+  "labels": {
+    "location": "myavailzone",
+    "cluster_name": "mycluster"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to k8s_cluster with region fallback 1'] = {
+  "type": "k8s_cluster",
+  "labels": {
+    "location": "myregion",
+    "cluster_name": "mycluster"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to k8s_container 1'] = {
+  "type": "k8s_container",
+  "labels": {
+    "location": "myavailzone",
+    "cluster_name": "mycluster",
+    "namespace_name": "myns",
+    "pod_name": "mypod",
+    "container_name": "mycontainer"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to k8s_container with region fallback 1'] = {
+  "type": "k8s_container",
+  "labels": {
+    "location": "myregion",
+    "cluster_name": "mycluster",
+    "namespace_name": "myns",
+    "pod_name": "mypod",
+    "container_name": "mycontainer"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to k8s_node 1'] = {
+  "type": "k8s_node",
+  "labels": {
+    "location": "myavailzone",
+    "cluster_name": "mycluster",
+    "node_name": "mynode"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to k8s_node with region fallback 1'] = {
+  "type": "k8s_node",
+  "labels": {
+    "location": "myregion",
+    "cluster_name": "mycluster",
+    "node_name": "mynode"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to k8s_pod 1'] = {
+  "type": "k8s_pod",
+  "labels": {
+    "location": "myavailzone",
+    "cluster_name": "mycluster",
+    "namespace_name": "myns",
+    "pod_name": "mypod"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to k8s_pod with region fallback 1'] = {
+  "type": "k8s_pod",
+  "labels": {
+    "location": "myregion",
+    "cluster_name": "mycluster",
+    "namespace_name": "myns",
+    "pod_name": "mypod"
+  }
+}

--- a/packages/opentelemetry-resource-util/package-lock.json
+++ b/packages/opentelemetry-resource-util/package-lock.json
@@ -18,6 +18,7 @@
 				"gts": "3.1.1",
 				"mocha": "9.2.2",
 				"nyc": "15.1.0",
+				"snap-shot-it": "^7.9.6",
 				"ts-mocha": "9.0.2",
 				"typescript": "4.8.4"
 			},
@@ -473,6 +474,19 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@bahmutov/data-driven": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@bahmutov/data-driven/-/data-driven-1.0.0.tgz",
+			"integrity": "sha512-YqW3hPS0RXriqjcCrLOTJj+LWe3c8JpwlL83k1ka1Q8U05ZjAKbGQZYeTzUd0NFEnnfPtsUiKGpFEBJG6kFuvg==",
+			"dev": true,
+			"dependencies": {
+				"check-more-types": "2.24.0",
+				"lazy-ass": "1.6.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -1103,6 +1117,12 @@
 			"integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
 			"dev": true
 		},
+		"node_modules/arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"dev": true
+		},
 		"node_modules/argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -1313,6 +1333,15 @@
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
 		},
+		"node_modules/check-more-types": {
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
+			"integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
 		"node_modules/chokidar": {
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -1339,6 +1368,12 @@
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
 			}
+		},
+		"node_modules/ci-info": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"dev": true
 		},
 		"node_modules/clean-stack": {
 			"version": "2.2.0",
@@ -1418,6 +1453,15 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
+		},
+		"node_modules/common-tags": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+			"integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0.0"
+			}
 		},
 		"node_modules/commondir": {
 			"version": "1.0.1",
@@ -1544,6 +1588,31 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/disparity": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/disparity/-/disparity-3.0.0.tgz",
+			"integrity": "sha512-n94Rzbv2ambRaFzrnBf34IEiyOdIci7maRpMkoQWB6xFYGA7Nbs0Z5YQzMfTeyQeelv23nayqOcssBoc6rKrgw==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"diff": "^4.0.1"
+			},
+			"bin": {
+				"disparity": "bin/disparity"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/disparity/node_modules/diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
 		"node_modules/doctrine": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1602,6 +1671,24 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/escape-quotes": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/escape-quotes/-/escape-quotes-1.0.2.tgz",
+			"integrity": "sha512-JpLFzklNReeakCpyj59s78P5F72q0ZUpDnp2BuIk9TtTjj2HMsgiWBChw17BlZT8dRhMtmSb1jE2+pTP1iFYyw==",
+			"dev": true,
+			"dependencies": {
+				"escape-string-regexp": "^1.0.5"
+			}
+		},
+		"node_modules/escape-quotes/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -2181,6 +2268,12 @@
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
 		},
+		"node_modules/folktale": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/folktale/-/folktale-2.3.2.tgz",
+			"integrity": "sha512-+8GbtQBwEqutP0v3uajDDoN64K2ehmHd0cjlghhxh0WpcfPzAIjPA03e1VvHlxL02FVGR0A6lwXsNQKn3H1RNQ==",
+			"dev": true
+		},
 		"node_modules/foreground-child": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
@@ -2420,6 +2513,27 @@
 				"node": ">= 0.4.0"
 			}
 		},
+		"node_modules/has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/has-ansi/node_modules/ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2427,6 +2541,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/has-only": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/has-only/-/has-only-1.1.1.tgz",
+			"integrity": "sha512-3GuFy9rDw0xvovCHb4SOKiRImbZ+a8boFBUyGNRPVd2mRyQOzYdau5G9nodUXC1ZKYN59hrHFkW1lgBQscYfTg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/hasha": {
@@ -2639,6 +2762,18 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/is-ci": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+			"dev": true,
+			"dependencies": {
+				"ci-info": "^2.0.0"
+			},
+			"bin": {
+				"is-ci": "bin.js"
+			}
+		},
 		"node_modules/is-core-module": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
@@ -2847,6 +2982,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/its-name": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/its-name/-/its-name-1.0.0.tgz",
+			"integrity": "sha512-GYUWFxViqxDvGzsNEItTEuOqqAQVx29Xl9Lh5YUqyJd6gPHTCMiIbjqcjjyUzsBUqEcgwIdRoydwgfFw1oYbhg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2915,6 +3059,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/lazy-ass": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+			"integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
+			"dev": true,
+			"engines": {
+				"node": "> 0.8"
 			}
 		},
 		"node_modules/levn": {
@@ -3592,6 +3745,15 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3862,6 +4024,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pluralize": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+			"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3956,6 +4127,18 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/quote": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
+			"integrity": "sha512-KHp3y3xDjuBhRx+tYKOgzPnVHMRlgpn2rU450GcU4PL24r1H6ls/hfPrxDwX2pvYMlwODHI2l8WwgoV69x5rUQ==",
+			"dev": true
+		},
+		"node_modules/ramda": {
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+			"integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
+			"dev": true
 		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
@@ -4383,6 +4566,150 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
+		"node_modules/snap-shot-compare": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/snap-shot-compare/-/snap-shot-compare-3.0.0.tgz",
+			"integrity": "sha512-bdwNOAGuKwPU+qsn0ASxTv+QfkXU+3VmkcDOkt965tes+JQQc8d6SfoLiEiRVhCey4v+ip2IjNUSbZm5nnkI9g==",
+			"dev": true,
+			"dependencies": {
+				"check-more-types": "2.24.0",
+				"debug": "4.1.1",
+				"disparity": "3.0.0",
+				"folktale": "2.3.2",
+				"lazy-ass": "1.6.0",
+				"strip-ansi": "5.2.0",
+				"variable-diff": "1.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/snap-shot-compare/node_modules/ansi-regex": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+			"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/snap-shot-compare/node_modules/debug": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+			"dev": true,
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/snap-shot-compare/node_modules/strip-ansi": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/snap-shot-core": {
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/snap-shot-core/-/snap-shot-core-10.2.4.tgz",
+			"integrity": "sha512-A7tkcfmvnRKge4VzFLAWA4UYMkvFY4TZKyL+D6hnHjI3HJ4pTepjG5DfR2ACeDKMzCSTQ5EwR2iOotI+Z37zsg==",
+			"dev": true,
+			"dependencies": {
+				"arg": "4.1.3",
+				"check-more-types": "2.24.0",
+				"common-tags": "1.8.0",
+				"debug": "4.3.1",
+				"escape-quotes": "1.0.2",
+				"folktale": "2.3.2",
+				"is-ci": "2.0.0",
+				"jsesc": "2.5.2",
+				"lazy-ass": "1.6.0",
+				"mkdirp": "1.0.4",
+				"pluralize": "8.0.0",
+				"quote": "0.4.0",
+				"ramda": "0.27.1"
+			},
+			"bin": {
+				"resave-snapshots": "bin/resave-snapshots.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/snap-shot-core/node_modules/debug": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/snap-shot-core/node_modules/mkdirp": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+			"dev": true,
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/snap-shot-it": {
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/snap-shot-it/-/snap-shot-it-7.9.6.tgz",
+			"integrity": "sha512-t/ADZfQ8EUk4J76S5cmynye7qg1ecUFqQfANiOMNy0sFmYUaqfx9K/AWwpdcpr3vFsDptM+zSuTtKD0A1EOLqA==",
+			"dev": true,
+			"dependencies": {
+				"@bahmutov/data-driven": "1.0.0",
+				"check-more-types": "2.24.0",
+				"common-tags": "1.8.0",
+				"debug": "4.3.1",
+				"has-only": "1.1.1",
+				"its-name": "1.0.0",
+				"lazy-ass": "1.6.0",
+				"pluralize": "8.0.0",
+				"ramda": "0.27.1",
+				"snap-shot-compare": "3.0.0",
+				"snap-shot-core": "10.2.4"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/snap-shot-it/node_modules/debug": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/source-map": {
@@ -4916,6 +5243,80 @@
 			"dependencies": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"node_modules/variable-diff": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/variable-diff/-/variable-diff-1.1.0.tgz",
+			"integrity": "sha512-0Jk/MsCNtL/fCuVIbsLxwXpABGZCzN57btcPbSsjOOAwkdHJ3Y58fo8BoUfG7jghnvglbwo+5Hk1KOJ2W2Ormw==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^1.1.1",
+				"object-assign": "^4.0.1"
+			}
+		},
+		"node_modules/variable-diff/node_modules/ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/variable-diff/node_modules/ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/variable-diff/node_modules/chalk": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^2.2.1",
+				"escape-string-regexp": "^1.0.2",
+				"has-ansi": "^2.0.0",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/variable-diff/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/variable-diff/node_modules/strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/variable-diff/node_modules/supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/webidl-conversions": {
@@ -5467,6 +5868,16 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@bahmutov/data-driven": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@bahmutov/data-driven/-/data-driven-1.0.0.tgz",
+			"integrity": "sha512-YqW3hPS0RXriqjcCrLOTJj+LWe3c8JpwlL83k1ka1Q8U05ZjAKbGQZYeTzUd0NFEnnfPtsUiKGpFEBJG6kFuvg==",
+			"dev": true,
+			"requires": {
+				"check-more-types": "2.24.0",
+				"lazy-ass": "1.6.0"
+			}
+		},
 		"@eslint/eslintrc": {
 			"version": "0.4.3",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -5907,6 +6318,12 @@
 			"integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
 			"dev": true
 		},
+		"arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"dev": true
+		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -6052,6 +6469,12 @@
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
 		},
+		"check-more-types": {
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
+			"integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
+			"dev": true
+		},
 		"chokidar": {
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -6067,6 +6490,12 @@
 				"normalize-path": "~3.0.0",
 				"readdirp": "~3.6.0"
 			}
+		},
+		"ci-info": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"dev": true
 		},
 		"clean-stack": {
 			"version": "2.2.0",
@@ -6126,6 +6555,12 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"common-tags": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+			"integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
 			"dev": true
 		},
 		"commondir": {
@@ -6220,6 +6655,24 @@
 				"path-type": "^4.0.0"
 			}
 		},
+		"disparity": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/disparity/-/disparity-3.0.0.tgz",
+			"integrity": "sha512-n94Rzbv2ambRaFzrnBf34IEiyOdIci7maRpMkoQWB6xFYGA7Nbs0Z5YQzMfTeyQeelv23nayqOcssBoc6rKrgw==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.1.0",
+				"diff": "^4.0.1"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+					"dev": true
+				}
+			}
+		},
 		"doctrine": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -6270,6 +6723,23 @@
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
 			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
 			"dev": true
+		},
+		"escape-quotes": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/escape-quotes/-/escape-quotes-1.0.2.tgz",
+			"integrity": "sha512-JpLFzklNReeakCpyj59s78P5F72q0ZUpDnp2BuIk9TtTjj2HMsgiWBChw17BlZT8dRhMtmSb1jE2+pTP1iFYyw==",
+			"dev": true,
+			"requires": {
+				"escape-string-regexp": "^1.0.5"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+					"dev": true
+				}
+			}
 		},
 		"escape-string-regexp": {
 			"version": "4.0.0",
@@ -6695,6 +7165,12 @@
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
 		},
+		"folktale": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/folktale/-/folktale-2.3.2.tgz",
+			"integrity": "sha512-+8GbtQBwEqutP0v3uajDDoN64K2ehmHd0cjlghhxh0WpcfPzAIjPA03e1VvHlxL02FVGR0A6lwXsNQKn3H1RNQ==",
+			"dev": true
+		},
 		"foreground-child": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
@@ -6856,10 +7332,33 @@
 				"function-bind": "^1.1.1"
 			}
 		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+					"dev": true
+				}
+			}
+		},
 		"has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true
+		},
+		"has-only": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/has-only/-/has-only-1.1.1.tgz",
+			"integrity": "sha512-3GuFy9rDw0xvovCHb4SOKiRImbZ+a8boFBUyGNRPVd2mRyQOzYdau5G9nodUXC1ZKYN59hrHFkW1lgBQscYfTg==",
 			"dev": true
 		},
 		"hasha": {
@@ -7026,6 +7525,15 @@
 				"binary-extensions": "^2.0.0"
 			}
 		},
+		"is-ci": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+			"dev": true,
+			"requires": {
+				"ci-info": "^2.0.0"
+			}
+		},
 		"is-core-module": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
@@ -7179,6 +7687,12 @@
 				"istanbul-lib-report": "^3.0.0"
 			}
 		},
+		"its-name": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/its-name/-/its-name-1.0.0.tgz",
+			"integrity": "sha512-GYUWFxViqxDvGzsNEItTEuOqqAQVx29Xl9Lh5YUqyJd6gPHTCMiIbjqcjjyUzsBUqEcgwIdRoydwgfFw1oYbhg==",
+			"dev": true
+		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7229,6 +7743,12 @@
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
 			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"dev": true
+		},
+		"lazy-ass": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+			"integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
 			"dev": true
 		},
 		"levn": {
@@ -7745,6 +8265,12 @@
 				}
 			}
 		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7939,6 +8465,12 @@
 				}
 			}
 		},
+		"pluralize": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+			"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+			"dev": true
+		},
 		"prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7991,6 +8523,18 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
 			"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+			"dev": true
+		},
+		"quote": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
+			"integrity": "sha512-KHp3y3xDjuBhRx+tYKOgzPnVHMRlgpn2rU450GcU4PL24r1H6ls/hfPrxDwX2pvYMlwODHI2l8WwgoV69x5rUQ==",
+			"dev": true
+		},
+		"ramda": {
+			"version": "0.27.1",
+			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+			"integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
 			"dev": true
 		},
 		"randombytes": {
@@ -8292,6 +8836,115 @@
 				"ansi-styles": "^4.0.0",
 				"astral-regex": "^2.0.0",
 				"is-fullwidth-code-point": "^3.0.0"
+			}
+		},
+		"snap-shot-compare": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/snap-shot-compare/-/snap-shot-compare-3.0.0.tgz",
+			"integrity": "sha512-bdwNOAGuKwPU+qsn0ASxTv+QfkXU+3VmkcDOkt965tes+JQQc8d6SfoLiEiRVhCey4v+ip2IjNUSbZm5nnkI9g==",
+			"dev": true,
+			"requires": {
+				"check-more-types": "2.24.0",
+				"debug": "4.1.1",
+				"disparity": "3.0.0",
+				"folktale": "2.3.2",
+				"lazy-ass": "1.6.0",
+				"strip-ansi": "5.2.0",
+				"variable-diff": "1.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+					"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+					"dev": true
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
+			}
+		},
+		"snap-shot-core": {
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/snap-shot-core/-/snap-shot-core-10.2.4.tgz",
+			"integrity": "sha512-A7tkcfmvnRKge4VzFLAWA4UYMkvFY4TZKyL+D6hnHjI3HJ4pTepjG5DfR2ACeDKMzCSTQ5EwR2iOotI+Z37zsg==",
+			"dev": true,
+			"requires": {
+				"arg": "4.1.3",
+				"check-more-types": "2.24.0",
+				"common-tags": "1.8.0",
+				"debug": "4.3.1",
+				"escape-quotes": "1.0.2",
+				"folktale": "2.3.2",
+				"is-ci": "2.0.0",
+				"jsesc": "2.5.2",
+				"lazy-ass": "1.6.0",
+				"mkdirp": "1.0.4",
+				"pluralize": "8.0.0",
+				"quote": "0.4.0",
+				"ramda": "0.27.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+					"dev": true
+				}
+			}
+		},
+		"snap-shot-it": {
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/snap-shot-it/-/snap-shot-it-7.9.6.tgz",
+			"integrity": "sha512-t/ADZfQ8EUk4J76S5cmynye7qg1ecUFqQfANiOMNy0sFmYUaqfx9K/AWwpdcpr3vFsDptM+zSuTtKD0A1EOLqA==",
+			"dev": true,
+			"requires": {
+				"@bahmutov/data-driven": "1.0.0",
+				"check-more-types": "2.24.0",
+				"common-tags": "1.8.0",
+				"debug": "4.3.1",
+				"has-only": "1.1.1",
+				"its-name": "1.0.0",
+				"lazy-ass": "1.6.0",
+				"pluralize": "8.0.0",
+				"ramda": "0.27.1",
+				"snap-shot-compare": "3.0.0",
+				"snap-shot-core": "10.2.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				}
 			}
 		},
 		"source-map": {
@@ -8703,6 +9356,64 @@
 			"requires": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"variable-diff": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/variable-diff/-/variable-diff-1.1.0.tgz",
+			"integrity": "sha512-0Jk/MsCNtL/fCuVIbsLxwXpABGZCzN57btcPbSsjOOAwkdHJ3Y58fo8BoUfG7jghnvglbwo+5Hk1KOJ2W2Ormw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^1.1.1",
+				"object-assign": "^4.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+					"integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+					"dev": true
+				}
 			}
 		},
 		"webidl-conversions": {

--- a/packages/opentelemetry-resource-util/package.json
+++ b/packages/opentelemetry-resource-util/package.json
@@ -13,6 +13,7 @@
     "compile": "tsc",
     "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
+    "update-snapshot-tests": "SNAPSHOT_UPDATE=1 npm run test",
     "fix": "gts fix",
     "pretest": "npm run compile"
   },
@@ -38,6 +39,11 @@
     "access": "public",
     "registry": "https://wombat-dressing-room.appspot.com"
   },
+  "config": {
+    "snap-shot-it": {
+      "sortSnapshots": true
+    }
+  },
   "devDependencies": {
     "@opentelemetry/api": "1.3.0",
     "@opentelemetry/resources": "1.8.0",
@@ -48,6 +54,7 @@
     "gts": "3.1.1",
     "mocha": "9.2.2",
     "nyc": "15.1.0",
+    "snap-shot-it": "^7.9.6",
     "ts-mocha": "9.0.2",
     "typescript": "4.8.4"
   },


### PR DESCRIPTION
This changes the logic to select a monitored resource for populating GCM monitored resource and the special `g.co/{type}/{label}` span labels to match the Go/collector exporter impl.

I don't expect this change to have a big negative impact on users even though it changes the behavior a bit–we never declared the resource mapping/detection stable anyway.