### PR TITLE
fix(monitoring-exporter): use correct value type for histogram/distribution metrics

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/__snapshots__/instrument-snapshot.test.ts.js
+++ b/packages/opentelemetry-cloud-monitoring-exporter/__snapshots__/instrument-snapshot.test.ts.js
@@ -150,7 +150,7 @@ exports['MetricExporter snapshot tests Histogram - DOUBLE 1'] = [
       "description": "histogram description",
       "displayName": "myhistogram",
       "metricKind": "CUMULATIVE",
-      "valueType": "DOUBLE",
+      "valueType": "DISTRIBUTION",
       "unit": "{myunit}",
       "labels": [
         {
@@ -193,7 +193,7 @@ exports['MetricExporter snapshot tests Histogram - DOUBLE 1'] = [
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "DOUBLE",
+          "valueType": "DISTRIBUTION",
           "points": [
             {
               "value": {
@@ -254,7 +254,7 @@ exports['MetricExporter snapshot tests Histogram - INT 1'] = [
       "description": "histogram description",
       "displayName": "myhistogram",
       "metricKind": "CUMULATIVE",
-      "valueType": "INT64",
+      "valueType": "DISTRIBUTION",
       "unit": "{myunit}",
       "labels": [
         {
@@ -297,7 +297,7 @@ exports['MetricExporter snapshot tests Histogram - INT 1'] = [
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "INT64",
+          "valueType": "DISTRIBUTION",
           "points": [
             {
               "value": {
@@ -1015,7 +1015,7 @@ exports['MetricExporter snapshot tests reconfigure with views counter with histo
       "description": "instrument description",
       "displayName": "myrenamedhistogram",
       "metricKind": "CUMULATIVE",
-      "valueType": "DOUBLE",
+      "valueType": "DISTRIBUTION",
       "unit": "{myunit}",
       "labels": []
     },
@@ -1041,7 +1041,7 @@ exports['MetricExporter snapshot tests reconfigure with views counter with histo
             }
           },
           "metricKind": "CUMULATIVE",
-          "valueType": "DOUBLE",
+          "valueType": "DISTRIBUTION",
           "points": [
             {
               "value": {

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -98,6 +98,9 @@ function transformMetricKind(metric: MetricData): MetricKind {
 
 /** Transforms a OpenTelemetry ValueType to a GCM ValueType. */
 function transformValueType(metric: MetricData): ValueType {
+  if (metric.dataPointType === DataPointType.HISTOGRAM) {
+    return ValueType.DISTRIBUTION;
+  }
   const {valueType} = metric.descriptor;
   if (valueType === OTValueType.DOUBLE) {
     return ValueType.DOUBLE;


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue/feature](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #473 

The `package-lock.json` file was not in sync with `package.json` when I went to make this change.  `npm ci` reported:

```
npm ERR! code EUSAGE
npm ERR! 
npm ERR! `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm ERR! 
npm ERR! Missing: @google-cloud/opentelemetry-resource-util@1.2.0 from lock file
```

I had to `npm i` to resolve the issue, which is the reason for the `package-lock.json` changes.  I can revert this change if you'd like, but it seems like the lock file was invalid, so that should probably be fixed.