### PR TITLE
chore(monitoring-exporter): add @opentelemetry/sdk-metrics as an explicit dev dependency

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/package-lock.json
+++ b/packages/opentelemetry-cloud-monitoring-exporter/package-lock.json
@@ -18,6 +18,7 @@
 				"@opentelemetry/api": "1.3.0",
 				"@opentelemetry/core": "1.8.0",
 				"@opentelemetry/resources": "1.8.0",
+				"@opentelemetry/sdk-metrics": "1.8.0",
 				"@types/mocha": "9.1.1",
 				"@types/nock": "11.1.0",
 				"@types/node": "14.18.34",
@@ -731,6 +732,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.3.0.tgz",
 			"integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -739,6 +741,7 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.8.0.tgz",
 			"integrity": "sha512-6SDjwBML4Am0AQmy7z1j6HGrWDgeK8awBRUvl1PGw6HayViMk4QpnUXvv4HTHisecgVBy43NE/cstWprm8tIfw==",
+			"dev": true,
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "1.8.0"
 			},
@@ -753,6 +756,7 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.8.0.tgz",
 			"integrity": "sha512-KSyMH6Jvss/PFDy16z5qkCK0ERlpyqixb1xwb73wLMvVq+j7i89lobDjw3JkpCcd1Ws0J6jAI4fw28Zufj2ssg==",
+			"dev": true,
 			"dependencies": {
 				"@opentelemetry/core": "1.8.0",
 				"@opentelemetry/semantic-conventions": "1.8.0"
@@ -768,7 +772,7 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.8.0.tgz",
 			"integrity": "sha512-+KYb+uj0vHhl8xzJO+oChS4oP1e+/2Wl3SXoHoIdcEjd1TQfDV+lxOm4oqxWq6wykXvI35/JHyejxSoT+qxGmg==",
-			"peer": true,
+			"dev": true,
 			"dependencies": {
 				"@opentelemetry/core": "1.8.0",
 				"@opentelemetry/resources": "1.8.0",
@@ -3472,7 +3476,8 @@
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true
 		},
 		"node_modules/lodash.truncate": {
 			"version": "4.4.2",
@@ -6574,12 +6579,14 @@
 		"@opentelemetry/api": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.3.0.tgz",
-			"integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ=="
+			"integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ==",
+			"dev": true
 		},
 		"@opentelemetry/core": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.8.0.tgz",
 			"integrity": "sha512-6SDjwBML4Am0AQmy7z1j6HGrWDgeK8awBRUvl1PGw6HayViMk4QpnUXvv4HTHisecgVBy43NE/cstWprm8tIfw==",
+			"dev": true,
 			"requires": {
 				"@opentelemetry/semantic-conventions": "1.8.0"
 			}
@@ -6588,6 +6595,7 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.8.0.tgz",
 			"integrity": "sha512-KSyMH6Jvss/PFDy16z5qkCK0ERlpyqixb1xwb73wLMvVq+j7i89lobDjw3JkpCcd1Ws0J6jAI4fw28Zufj2ssg==",
+			"dev": true,
 			"requires": {
 				"@opentelemetry/core": "1.8.0",
 				"@opentelemetry/semantic-conventions": "1.8.0"
@@ -6597,7 +6605,7 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.8.0.tgz",
 			"integrity": "sha512-+KYb+uj0vHhl8xzJO+oChS4oP1e+/2Wl3SXoHoIdcEjd1TQfDV+lxOm4oqxWq6wykXvI35/JHyejxSoT+qxGmg==",
-			"peer": true,
+			"dev": true,
 			"requires": {
 				"@opentelemetry/core": "1.8.0",
 				"@opentelemetry/resources": "1.8.0",
@@ -8582,7 +8590,8 @@
 		"lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true
 		},
 		"lodash.truncate": {
 			"version": "4.4.2",

--- a/packages/opentelemetry-cloud-monitoring-exporter/package.json
+++ b/packages/opentelemetry-cloud-monitoring-exporter/package.json
@@ -48,6 +48,7 @@
     "@opentelemetry/api": "1.3.0",
     "@opentelemetry/core": "1.8.0",
     "@opentelemetry/resources": "1.8.0",
+    "@opentelemetry/sdk-metrics": "1.8.0",
     "@types/mocha": "9.1.1",
     "@types/nock": "11.1.0",
     "@types/node": "14.18.34",


### PR DESCRIPTION
Addresses this comment https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/pull/474#issuecomment-1353761243