### PR TITLE
chore: fix e2e Dockerfile build issue

### DIFF
--- a/e2e-test-server/Dockerfile
+++ b/e2e-test-server/Dockerfile
@@ -25,9 +25,11 @@ USER root
 RUN chown node:node $SRC
 USER node
 # copy local dependencies
-COPY --chown=node:node packages/ packages/
-COPY --chown=node:node scripts/ scripts/
 COPY --chown=node:node lerna.json package.json package-lock.json ./
+COPY --chown=node:node scripts/ scripts/
+COPY --chown=node:node packages/ packages/
+# Install dev tools in the root of the repo
+RUN npm install --ignore-scripts
 # copy package.json
 COPY --chown=node:node e2e-test-server/package.json e2e-test-server/package-lock.json e2e-test-server/
 # bootstrap without compile


### PR DESCRIPTION
Was failing because it was a different lerna version than specified in the `package.json`. Running `npm install` before `npx lerna ...` makes it use the locally installed version. # Please enter the commit message for your changes. Lines starting
