### PR TITLE
test: use @vercel/ncc to bundle e2e-test-server and eliminate dead code for smaller containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .git
 **/node_modules/
 **/Dockerfile
+**/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ node_modules/
 npm-debug.log
 .nyc_output/
 build/
+dist/
 
 #backup files
 *--

--- a/cloudbuild-e2e-cloud-functions-gen2.yaml
+++ b/cloudbuild-e2e-cloud-functions-gen2.yaml
@@ -24,16 +24,17 @@ steps:
       # bootstrap only the packages needed for e2e-test-server
       npx lerna bootstrap --scope=@google-cloud/e2e-test-server --include-dependencies
 
-      # build tarballs for the dependencies to include in the zip
-      dependencies=$(
-        npx lerna list --scope=@google-cloud/e2e-test-server --include-dependencies --json | jq '.[].location' | xargs
-      )
+      # builds a small self contained bundle with @vercel/ncc under dist/
       cd e2e-test-server
-      npm pack $dependencies
-      # install them to point package.json at the local tarballs
-      npm install --save *.tgz
+      # --external will avoid bundling functions-framework. Needed so we only have one copy of
+      # global variables in that package when GCF executes it.
+      npm run bundle -- --external @google-cloud/functions-framework
 
-      # zip it up into a source zip for Cloud Functions, excluding node_modules
+      # create a new fake package.json in dist/ and zip it up into a source zip for Cloud
+      # Functions
+      cd dist
+      npm init -y
+      npm install --save @google-cloud/functions-framework
       zip -r function-source.zip . -x "node_modules*"
 
   # Run the test
@@ -43,7 +44,7 @@ steps:
     env: ["PROJECT_ID=$PROJECT_ID"]
     args:
       - cloud-functions-gen2
-      - --functionsource=/workspace/e2e-test-server/function-source.zip
+      - --functionsource=/workspace/e2e-test-server/dist/function-source.zip
       - --runtime=nodejs16
       - --entrypoint=cloudFunctionHandler
 

--- a/e2e-test-server/Dockerfile
+++ b/e2e-test-server/Dockerfile
@@ -26,14 +26,10 @@ RUN npm install --ignore-scripts
 COPY . ./
 # bootstrap only the packages needed for e2e test server
 RUN npx lerna@latest bootstrap --scope=@google-cloud/e2e-test-server --include-dependencies
-# dereference lerna symlinks so we don't need to copy out the whole monorepo
-RUN TMPDIR=$(mktemp -d) && \
-    cp --dereference --recursive e2e-test-server/node_modules/@google-cloud $TMPDIR/ && \
-    rm -rf e2e-test-server/node_modules/@google-cloud && \
-    mv $TMPDIR/@google-cloud e2e-test-server/node_modules/@google-cloud
-RUN npm prune --omit=dev
+# builds a small self contained bundle with @vercel/ncc under dist/
+RUN cd e2e-test-server && npm run bundle
 
 FROM node-base
 USER node
-COPY --from=build-base --chown=node:node $SRC/e2e-test-server ./
-ENTRYPOINT ["node", "build/src/index.js"]
+COPY --from=build-base --chown=node:node $SRC/e2e-test-server/dist ./
+ENTRYPOINT ["node", "index.js"]

--- a/e2e-test-server/package-lock.json
+++ b/e2e-test-server/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@types/express": "^4.17.15",
         "@types/node": "14.18.36",
+        "@vercel/ncc": "^0.36.0",
         "gts": "3.1.1",
         "typescript": "4.9.4"
       },
@@ -856,6 +857,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.0.tgz",
+      "integrity": "sha512-/ZTUJ/ZkRt694k7KJNimgmHjtQcRuVwsST2Z6XfYveQIuBbHR+EqkTc1jfgPkQmMyk/vtpxo3nVxe8CNuau86A==",
+      "dev": true,
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
       }
     },
     "node_modules/abort-controller": {
@@ -5672,6 +5682,12 @@
         "@typescript-eslint/types": "4.33.0",
         "eslint-visitor-keys": "^2.0.0"
       }
+    },
+    "@vercel/ncc": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.0.tgz",
+      "integrity": "sha512-/ZTUJ/ZkRt694k7KJNimgmHjtQcRuVwsST2Z6XfYveQIuBbHR+EqkTc1jfgPkQmMyk/vtpxo3nVxe8CNuau86A==",
+      "dev": true
     },
     "abort-controller": {
       "version": "3.0.0",

--- a/e2e-test-server/package.json
+++ b/e2e-test-server/package.json
@@ -24,11 +24,12 @@
     "pretest": "npm run compile",
     "posttest": "npm run lint",
     "server": "node build/src/index.js",
-    "gcp-build": "npm run compile"
+    "bundle": "ncc build src/index.ts"
   },
   "devDependencies": {
     "@types/express": "^4.17.15",
     "@types/node": "14.18.36",
+    "@vercel/ncc": "^0.36.0",
     "gts": "3.1.1",
     "typescript": "4.9.4"
   },


### PR DESCRIPTION
Container sizes are much smaller:

![image](https://user-images.githubusercontent.com/1510004/213555637-b406bba7-bfdd-43a2-8601-98cdf18db0d7.png)

This reduction in layer size makes e2e tests faster by reducing the amount to be uploaded/downloaded and compressed/decompressed. Build time is reduced by ~1 minute. 