### PR TITLE
chore: un-export the unreleased resource detector until after the next release

### DIFF
--- a/e2e-test-server/src/scenarios.ts
+++ b/e2e-test-server/src/scenarios.ts
@@ -25,7 +25,8 @@ import {
   TraceExporter,
   TraceExporterOptions,
 } from '@google-cloud/opentelemetry-cloud-trace-exporter';
-import {GcpDetector} from '@google-cloud/opentelemetry-resource-util';
+// TOOD(#518) remove full import path once it is expose in the package's root index.ts file
+import {GcpDetector} from '@google-cloud/opentelemetry-resource-util/build/src/detector/detector';
 import * as constants from './constants';
 import {context, SpanKind} from '@opentelemetry/api';
 import {AsyncHooksContextManager} from '@opentelemetry/context-async-hooks';

--- a/packages/opentelemetry-resource-util/src/index.ts
+++ b/packages/opentelemetry-resource-util/src/index.ts
@@ -283,4 +283,5 @@ function createMonitoredResource(
   };
 }
 
-export {GcpDetector} from './detector/detector';
+// TODO(518): publicly expose the resource detector
+// export {GcpDetector} from './detector/detector';


### PR DESCRIPTION
This is in order to cut a new release (https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/509) but at this point we haven't decided on some strategies with new resource detector. For now, we can just hide it and postpone the decision until the subsequent release.