### PR TITLE
Revert "chore: un-export the unreleased resource detector until after the next release"

### DIFF
--- a/e2e-test-server/src/scenarios.ts
+++ b/e2e-test-server/src/scenarios.ts
@@ -25,8 +25,7 @@ import {
   TraceExporter,
   TraceExporterOptions,
 } from '@google-cloud/opentelemetry-cloud-trace-exporter';
-// TOOD(#518) remove full import path once it is expose in the package's root index.ts file
-import {GcpDetector} from '@google-cloud/opentelemetry-resource-util/build/src/detector/detector';
+import {GcpDetector} from '@google-cloud/opentelemetry-resource-util';
 import * as constants from './constants';
 import {context, SpanKind} from '@opentelemetry/api';
 import {AsyncHooksContextManager} from '@opentelemetry/context-async-hooks';

--- a/packages/opentelemetry-resource-util/src/index.ts
+++ b/packages/opentelemetry-resource-util/src/index.ts
@@ -283,5 +283,4 @@ function createMonitoredResource(
   };
 }
 
-// TODO(518): publicly expose the resource detector
-// export {GcpDetector} from './detector/detector';
+export {GcpDetector} from './detector/detector';


### PR DESCRIPTION
Reverts GoogleCloudPlatform/opentelemetry-operations-js#519

Decided we don't actually need this since the next release will be a major version bump regardless.