### PR TITLE
fix: detect OTel host.name property from instance/name instead of hostname

### DIFF
--- a/packages/opentelemetry-resource-util/src/detector/gce.ts
+++ b/packages/opentelemetry-resource-util/src/detector/gce.ts
@@ -22,7 +22,7 @@ import * as metadata from 'gcp-metadata';
 
 const MACHINE_TYPE_METADATA_ATTR = 'machine-type';
 const ID_METADATA_ATTR = 'id';
-const HOSTNAME_METADATA_ATTR = 'hostname';
+const HOST_NAME_METADATA_ATTR = 'name';
 const ZONE_METADATA_ATTR = 'zone';
 
 export async function onGce(): Promise<boolean> {
@@ -63,7 +63,7 @@ export async function hostId(): Promise<string> {
  * is true before calling this, or it may throw exceptions.
  */
 export async function hostName(): Promise<string> {
-  return metadata.instance<string>(HOSTNAME_METADATA_ATTR);
+  return metadata.instance<string>(HOST_NAME_METADATA_ATTR);
 }
 
 /**

--- a/packages/opentelemetry-resource-util/test/detector/detector.test.ts
+++ b/packages/opentelemetry-resource-util/test/detector/detector.test.ts
@@ -89,8 +89,8 @@ describe('GcpDetector', () => {
       .withArgs('machine-type')
       .resolves('fake-machine-type')
 
-      .withArgs('hostname')
-      .resolves('fake-hostname')
+      .withArgs('name')
+      .resolves('fake-name')
 
       .withArgs('zone')
       .resolves('projects/233510669999/zones/us-east4-b');
@@ -103,7 +103,7 @@ describe('GcpDetector', () => {
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
       'host.id': '12345',
-      'host.name': 'fake-hostname',
+      'host.name': 'fake-name',
       'host.type': 'fake-machine-type',
     });
   });

--- a/packages/opentelemetry-resource-util/test/detector/gce.test.ts
+++ b/packages/opentelemetry-resource-util/test/detector/gce.test.ts
@@ -75,10 +75,10 @@ describe('GCE', () => {
   });
 
   it('detects host name', async () => {
-    metadataStub.instance.withArgs('hostname').resolves('fake-hostname');
+    metadataStub.instance.withArgs('name').resolves('fake-name');
 
     const hostName = await gce.hostName();
-    assert.strictEqual(hostName, 'fake-hostname');
+    assert.strictEqual(hostName, 'fake-name');
   });
 
   describe('zone and region', () => {


### PR DESCRIPTION
This is a bug. See Go impl https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/a62ae2cc5958c5ea59cbc9064cd4a76a4af25da9/detectors/gcp/gce.go#L43