### PR TITLE
chore: add renovate allowedPostUpgradeCommands option

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     "enabled": true
   },
   "labels": ["dependencies"],
+  "allowedPostUpgradeCommands": ["^npm run update-snapshot-tests$"],
   "packageRules": [
     {
       "matchPackageNames": ["typescript"],


### PR DESCRIPTION
See this comment on recent run for context: https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/pull/537

[docs link](https://docs.renovatebot.com/self-hosted-configuration/#allowedpostupgradecommands)