### PR TITLE
chore: remove renovate postUpgradeTasks option

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,12 +17,7 @@
     },
     {
       "matchPackagePrefixes": ["@opentelemetry/"],
-      "groupName": "opentelemetry upstream",
-      "postUpgradeTasks": {
-        "commands": ["npm run update-snapshot-tests"],
-        "fileFilters": ["**/__snapshots__/**/*.js"],
-        "executionMode": "branch"
-      }
+      "groupName": "opentelemetry upstream"
     }
   ]
 }


### PR DESCRIPTION
It unfortunately [only works with self-hosted renovate](https://docs.renovatebot.com/configuration-options/#postupgradetasks:~:text=Post%2Dupgrade%20tasks%20can%20only%20be%20used%20on%20self%2Dhosted%20Renovate%20instances.).
