### PR TITLE
feat(resource-util): implement the DetectorSync resource detector interface

### DIFF
--- a/e2e-test-server/src/scenarios.ts
+++ b/e2e-test-server/src/scenarios.ts
@@ -20,12 +20,16 @@ import {
   TracerConfig,
 } from '@opentelemetry/sdk-trace-base';
 import {AlwaysOnSampler} from '@opentelemetry/sdk-trace-base';
-import {Resource, envDetector, detectResources} from '@opentelemetry/resources';
+import {
+  Resource,
+  envDetector,
+  detectResourcesSync,
+} from '@opentelemetry/resources';
 import {
   TraceExporter,
   TraceExporterOptions,
 } from '@google-cloud/opentelemetry-cloud-trace-exporter';
-import {GcpDetector} from '@google-cloud/opentelemetry-resource-util';
+import {GcpDetectorSync} from '@google-cloud/opentelemetry-resource-util';
 import * as constants from './constants';
 import {context, SpanKind} from '@opentelemetry/api';
 import {AsyncHooksContextManager} from '@opentelemetry/context-async-hooks';
@@ -128,8 +132,8 @@ async function detectResource(request: Request): Promise<Response> {
     },
     {
       tracerConfig: {
-        resource: await detectResources({
-          detectors: [new GcpDetector(), envDetector],
+        resource: detectResourcesSync({
+          detectors: [new GcpDetectorSync(), envDetector],
         }),
       },
       exporterConfig: {

--- a/packages/opentelemetry-resource-util/src/index.ts
+++ b/packages/opentelemetry-resource-util/src/index.ts
@@ -283,4 +283,4 @@ function createMonitoredResource(
   };
 }
 
-export {GcpDetector} from './detector/detector';
+export {GcpDetector, GcpDetectorSync} from './detector/detector';

--- a/packages/opentelemetry-resource-util/test/detector/detector.test.ts
+++ b/packages/opentelemetry-resource-util/test/detector/detector.test.ts
@@ -15,7 +15,7 @@
 import * as sinon from 'sinon';
 import * as metadata from 'gcp-metadata';
 
-import {GcpDetector} from '../../src/detector/detector';
+import {GcpDetector, GcpDetectorSync} from '../../src/detector/detector';
 import * as assert from 'assert';
 
 describe('GcpDetector', () => {
@@ -204,6 +204,205 @@ describe('GcpDetector', () => {
     metadataStub.project.rejects();
 
     const resource = await new GcpDetector().detect();
+    assert.deepStrictEqual(resource.attributes, {});
+  });
+});
+
+describe('GcpDetectorSync', () => {
+  let metadataStub: sinon.SinonStubbedInstance<typeof metadata>;
+  let envStub: NodeJS.ProcessEnv;
+  beforeEach(() => {
+    metadataStub = sinon.stub(metadata);
+    metadataStub.isAvailable.resolves(true);
+    metadataStub.project.withArgs('project-id').resolves('fake-project-id');
+
+    envStub = sinon.replace(process, 'env', {});
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('returns empty resource when metadata server is not available', async () => {
+    metadataStub.isAvailable.resolves(false);
+    const resource = new GcpDetectorSync().detect();
+    await resource.waitForAsyncAttributes?.();
+    assert.deepStrictEqual(resource.attributes, {});
+  });
+
+  describe('detects a GKE resource', () => {
+    beforeEach(() => {
+      envStub.KUBERNETES_SERVICE_HOST = 'fake-service-host';
+      metadataStub.instance
+        .withArgs('id')
+        .resolves(12345)
+
+        .withArgs('attributes/cluster-name')
+        .resolves('fake-cluster-name');
+    });
+
+    it('zonal', async () => {
+      metadataStub.instance
+        .withArgs('attributes/cluster-location')
+        .resolves('us-east4-b');
+      const resource = new GcpDetectorSync().detect();
+      await resource.waitForAsyncAttributes?.();
+      assert.deepStrictEqual(resource.attributes, {
+        'cloud.account.id': 'fake-project-id',
+        'cloud.availability_zone': 'us-east4-b',
+        'cloud.platform': 'gcp_kubernetes_engine',
+        'cloud.provider': 'gcp',
+        'host.id': '12345',
+        'k8s.cluster.name': 'fake-cluster-name',
+      });
+    });
+
+    it('regional', async () => {
+      metadataStub.instance
+        .withArgs('attributes/cluster-location')
+        .resolves('us-east4');
+      const resource = new GcpDetectorSync().detect();
+      await resource.waitForAsyncAttributes?.();
+      assert.deepStrictEqual(resource.attributes, {
+        'cloud.account.id': 'fake-project-id',
+        'cloud.platform': 'gcp_kubernetes_engine',
+        'cloud.provider': 'gcp',
+        'cloud.region': 'us-east4',
+        'host.id': '12345',
+        'k8s.cluster.name': 'fake-cluster-name',
+      });
+    });
+  });
+
+  it('detects a GCE resource', async () => {
+    metadataStub.instance
+      .withArgs('id')
+      .resolves(12345)
+
+      .withArgs('machine-type')
+      .resolves('fake-machine-type')
+
+      .withArgs('name')
+      .resolves('fake-name')
+
+      .withArgs('zone')
+      .resolves('projects/233510669999/zones/us-east4-b');
+
+    const resource = new GcpDetectorSync().detect();
+    await resource.waitForAsyncAttributes?.();
+    assert.deepStrictEqual(resource.attributes, {
+      'cloud.account.id': 'fake-project-id',
+      'cloud.availability_zone': 'us-east4-b',
+      'cloud.platform': 'gcp_compute_engine',
+      'cloud.provider': 'gcp',
+      'cloud.region': 'us-east4',
+      'host.id': '12345',
+      'host.name': 'fake-name',
+      'host.type': 'fake-machine-type',
+    });
+  });
+
+  it('detects a Cloud Run resource', async () => {
+    envStub.K_CONFIGURATION = 'fake-configuration';
+    envStub.K_SERVICE = 'fake-service';
+    envStub.K_REVISION = 'fake-revision';
+    metadataStub.instance
+      .withArgs('id')
+      .resolves(12345)
+
+      .withArgs('region')
+      .resolves('projects/233510669999/regions/us-east4');
+
+    const resource = new GcpDetectorSync().detect();
+    await resource.waitForAsyncAttributes?.();
+    assert.deepStrictEqual(resource.attributes, {
+      'cloud.account.id': 'fake-project-id',
+      'cloud.platform': 'gcp_cloud_run',
+      'cloud.provider': 'gcp',
+      'cloud.region': 'us-east4',
+      'faas.id': '12345',
+      'faas.name': 'fake-service',
+      'faas.version': 'fake-revision',
+    });
+  });
+
+  it('detects a Cloud Functions resource', async () => {
+    envStub.FUNCTION_TARGET = 'fake-function-target';
+    envStub.K_SERVICE = 'fake-service';
+    envStub.K_REVISION = 'fake-revision';
+    metadataStub.instance
+      .withArgs('id')
+      .resolves(12345)
+
+      .withArgs('region')
+      .resolves('projects/233510669999/regions/us-east4');
+
+    const resource = new GcpDetectorSync().detect();
+    await resource.waitForAsyncAttributes?.();
+    assert.deepStrictEqual(resource.attributes, {
+      'cloud.account.id': 'fake-project-id',
+      'cloud.platform': 'gcp_cloud_functions',
+      'cloud.provider': 'gcp',
+      'cloud.region': 'us-east4',
+      'faas.id': '12345',
+      'faas.name': 'fake-service',
+      'faas.version': 'fake-revision',
+    });
+  });
+
+  it('detects a App Engine Standard resource', async () => {
+    envStub.GAE_ENV = 'standard';
+    envStub.GAE_SERVICE = 'fake-service';
+    envStub.GAE_VERSION = 'fake-version';
+    envStub.GAE_INSTANCE = 'fake-instance';
+    metadataStub.instance.withArgs('zone').resolves('us-east4-b');
+    metadataStub.instance
+      .withArgs('region')
+      .resolves('projects/233510669999/regions/us-east4');
+
+    const resource = new GcpDetectorSync().detect();
+    await resource.waitForAsyncAttributes?.();
+    assert.deepStrictEqual(resource.attributes, {
+      'cloud.account.id': 'fake-project-id',
+      'cloud.availability_zone': 'us-east4-b',
+      'cloud.platform': 'gcp_app_engine',
+      'cloud.provider': 'gcp',
+      'cloud.region': 'us-east4',
+      'faas.id': 'fake-instance',
+      'faas.name': 'fake-service',
+      'faas.version': 'fake-version',
+    });
+  });
+
+  it('detects a App Engine Flex resource', async () => {
+    envStub.GAE_SERVICE = 'fake-service';
+    envStub.GAE_VERSION = 'fake-version';
+    envStub.GAE_INSTANCE = 'fake-instance';
+    metadataStub.instance
+      .withArgs('zone')
+      .resolves('projects/233510669999/zones/us-east4-b');
+
+    const resource = new GcpDetectorSync().detect();
+    await resource.waitForAsyncAttributes?.();
+    assert.deepStrictEqual(resource.attributes, {
+      'cloud.account.id': 'fake-project-id',
+      'cloud.availability_zone': 'us-east4-b',
+      'cloud.platform': 'gcp_app_engine',
+      'cloud.provider': 'gcp',
+      'cloud.region': 'us-east4',
+      'faas.id': 'fake-instance',
+      'faas.name': 'fake-service',
+      'faas.version': 'fake-version',
+    });
+  });
+
+  it('detects empty resource when nothing else can be detected', async () => {
+    // gcp-metadata throws when it can't access the metadata server
+    metadataStub.instance.rejects();
+    metadataStub.project.rejects();
+
+    const resource = new GcpDetectorSync().detect();
+    await resource.waitForAsyncAttributes?.();
     assert.deepStrictEqual(resource.attributes, {});
   });
 });


### PR DESCRIPTION
For more context, this new interface was added upstream (and the old one deprecated) so that resource detection will be "synchronous" and the SDK initialization can complete before any other code runs. For auto instrumentation, this is important so that monkey patching is finished before the user imports anything.

The deprecated `GcpDetector` will be removed in the next major version