### PR TITLE
fix: use faas.instance instead of faas.id in resource detectors

### DIFF
--- a/cloudbuild-e2e-cloud-functions-gen2.yaml
+++ b/cloudbuild-e2e-cloud-functions-gen2.yaml
@@ -52,5 +52,5 @@ steps:
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.16.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-cloud-run.yaml
+++ b/cloudbuild-e2e-cloud-run.yaml
@@ -33,5 +33,5 @@ steps:
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.16.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gae.yaml
+++ b/cloudbuild-e2e-gae.yaml
@@ -35,5 +35,5 @@ steps:
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.16.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gce.yaml
+++ b/cloudbuild-e2e-gce.yaml
@@ -35,5 +35,5 @@ steps:
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.16.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gke.yaml
+++ b/cloudbuild-e2e-gke.yaml
@@ -33,5 +33,5 @@ steps:
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.16.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-local.yaml
+++ b/cloudbuild-e2e-local.yaml
@@ -35,5 +35,5 @@ steps:
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
-  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.16.0
+  _TEST_RUNNER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-e2e-testing:0.17.0
   _TEST_SERVER_IMAGE: gcr.io/${PROJECT_ID}/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}

--- a/packages/opentelemetry-resource-util/src/detector/detector.ts
+++ b/packages/opentelemetry-resource-util/src/detector/detector.ts
@@ -66,35 +66,37 @@ async function gkeResource(): Promise<Resource> {
 }
 
 async function cloudRunResource(): Promise<Resource> {
-  const [faasName, faasVersion, faasId, faasCloudRegion] = await Promise.all([
-    faas.faasName(),
-    faas.faasVersion(),
-    faas.faasId(),
-    faas.faasCloudRegion(),
-  ]);
+  const [faasName, faasVersion, faasInstance, faasCloudRegion] =
+    await Promise.all([
+      faas.faasName(),
+      faas.faasVersion(),
+      faas.faasInstance(),
+      faas.faasCloudRegion(),
+    ]);
 
   return await makeResource({
     [Semconv.CLOUD_PLATFORM]: CloudPlatformValues.GCP_CLOUD_RUN,
     [Semconv.FAAS_NAME]: faasName,
     [Semconv.FAAS_VERSION]: faasVersion,
-    [Semconv.FAAS_ID]: faasId,
+    [Semconv.FAAS_INSTANCE]: faasInstance,
     [Semconv.CLOUD_REGION]: faasCloudRegion,
   });
 }
 
 async function cloudFunctionsResource(): Promise<Resource> {
-  const [faasName, faasVersion, faasId, faasCloudRegion] = await Promise.all([
-    faas.faasName(),
-    faas.faasVersion(),
-    faas.faasId(),
-    faas.faasCloudRegion(),
-  ]);
+  const [faasName, faasVersion, faasInstance, faasCloudRegion] =
+    await Promise.all([
+      faas.faasName(),
+      faas.faasVersion(),
+      faas.faasInstance(),
+      faas.faasCloudRegion(),
+    ]);
 
   return await makeResource({
     [Semconv.CLOUD_PLATFORM]: CloudPlatformValues.GCP_CLOUD_FUNCTIONS,
     [Semconv.FAAS_NAME]: faasName,
     [Semconv.FAAS_VERSION]: faasVersion,
-    [Semconv.FAAS_ID]: faasId,
+    [Semconv.FAAS_INSTANCE]: faasInstance,
     [Semconv.CLOUD_REGION]: faasCloudRegion,
   });
 }
@@ -109,7 +111,7 @@ async function gaeResource(): Promise<Resource> {
   } else {
     ({zone, region} = await gce.availabilityZoneAndRegion());
   }
-  const [faasName, faasVersion, faasId] = await Promise.all([
+  const [faasName, faasVersion, faasInstance] = await Promise.all([
     gae.serviceName(),
     gae.serviceVersion(),
     gae.serviceInstance(),
@@ -119,7 +121,7 @@ async function gaeResource(): Promise<Resource> {
     [Semconv.CLOUD_PLATFORM]: CloudPlatformValues.GCP_APP_ENGINE,
     [Semconv.FAAS_NAME]: faasName,
     [Semconv.FAAS_VERSION]: faasVersion,
-    [Semconv.FAAS_ID]: faasId,
+    [Semconv.FAAS_INSTANCE]: faasInstance,
     [Semconv.CLOUD_AVAILABILITY_ZONE]: zone,
     [Semconv.CLOUD_REGION]: region,
   });

--- a/packages/opentelemetry-resource-util/src/detector/faas.ts
+++ b/packages/opentelemetry-resource-util/src/detector/faas.ts
@@ -55,7 +55,7 @@ export async function faasVersion(): Promise<string> {
  * onCloudRun()} or {@link onCloudFunctions()} is true before calling this, or it may throw
  * exceptions.
  */
-export async function faasId(): Promise<string> {
+export async function faasInstance(): Promise<string> {
   // May be a bignumber.js BigNumber which can just be converted with toString(). See
   // https://github.com/googleapis/gcp-metadata#take-care-with-large-number-valued-properties
   const id = await metadata.instance<number | Object>(ID_METADATA_ATTR);

--- a/packages/opentelemetry-resource-util/src/index.ts
+++ b/packages/opentelemetry-resource-util/src/index.ts
@@ -138,7 +138,7 @@ const MAPPINGS = {
     },
     [GAE_MODULE_ID]: {otelKeys: [SemanticResourceAttributes.FAAS_NAME]},
     [GAE_VERSION_ID]: {otelKeys: [SemanticResourceAttributes.FAAS_VERSION]},
-    [INSTANCE_ID]: {otelKeys: [SemanticResourceAttributes.FAAS_ID]},
+    [INSTANCE_ID]: {otelKeys: [SemanticResourceAttributes.FAAS_INSTANCE]},
   },
   [GENERIC_TASK]: {
     [LOCATION]: {

--- a/packages/opentelemetry-resource-util/test/detector/detector.test.ts
+++ b/packages/opentelemetry-resource-util/test/detector/detector.test.ts
@@ -125,7 +125,7 @@ describe('GcpDetector', () => {
       'cloud.platform': 'gcp_cloud_run',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
-      'faas.id': '12345',
+      'faas.instance': '12345',
       'faas.name': 'fake-service',
       'faas.version': 'fake-revision',
     });
@@ -148,7 +148,7 @@ describe('GcpDetector', () => {
       'cloud.platform': 'gcp_cloud_functions',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
-      'faas.id': '12345',
+      'faas.instance': '12345',
       'faas.name': 'fake-service',
       'faas.version': 'fake-revision',
     });
@@ -171,7 +171,7 @@ describe('GcpDetector', () => {
       'cloud.platform': 'gcp_app_engine',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
-      'faas.id': 'fake-instance',
+      'faas.instance': 'fake-instance',
       'faas.name': 'fake-service',
       'faas.version': 'fake-version',
     });
@@ -192,7 +192,7 @@ describe('GcpDetector', () => {
       'cloud.platform': 'gcp_app_engine',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
-      'faas.id': 'fake-instance',
+      'faas.instance': 'fake-instance',
       'faas.name': 'fake-service',
       'faas.version': 'fake-version',
     });
@@ -320,7 +320,7 @@ describe('GcpDetectorSync', () => {
       'cloud.platform': 'gcp_cloud_run',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
-      'faas.id': '12345',
+      'faas.instance': '12345',
       'faas.name': 'fake-service',
       'faas.version': 'fake-revision',
     });
@@ -344,7 +344,7 @@ describe('GcpDetectorSync', () => {
       'cloud.platform': 'gcp_cloud_functions',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
-      'faas.id': '12345',
+      'faas.instance': '12345',
       'faas.name': 'fake-service',
       'faas.version': 'fake-revision',
     });
@@ -368,7 +368,7 @@ describe('GcpDetectorSync', () => {
       'cloud.platform': 'gcp_app_engine',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
-      'faas.id': 'fake-instance',
+      'faas.instance': 'fake-instance',
       'faas.name': 'fake-service',
       'faas.version': 'fake-version',
     });
@@ -390,7 +390,7 @@ describe('GcpDetectorSync', () => {
       'cloud.platform': 'gcp_app_engine',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
-      'faas.id': 'fake-instance',
+      'faas.instance': 'fake-instance',
       'faas.name': 'fake-service',
       'faas.version': 'fake-version',
     });

--- a/packages/opentelemetry-resource-util/test/detector/faas.test.ts
+++ b/packages/opentelemetry-resource-util/test/detector/faas.test.ts
@@ -67,8 +67,8 @@ describe('FaaS (Cloud Run/Functions)', () => {
     it('as a number', async () => {
       metadataStub.instance.withArgs('id').resolves(12345);
 
-      const faasId = await faas.faasId();
-      assert.strictEqual(faasId, '12345');
+      const faasInstance = await faas.faasInstance();
+      assert.strictEqual(faasInstance, '12345');
     });
 
     it('as a BigNumber', async () => {
@@ -76,8 +76,8 @@ describe('FaaS (Cloud Run/Functions)', () => {
         .withArgs('id')
         .resolves(new BigNumber('2459451723172637654'));
 
-      const faasId = await faas.faasId();
-      assert.strictEqual(faasId, '2459451723172637654');
+      const faasInstance = await faas.faasInstance();
+      assert.strictEqual(faasInstance, '2459451723172637654');
     });
   });
 

--- a/packages/opentelemetry-resource-util/test/index.test.ts
+++ b/packages/opentelemetry-resource-util/test/index.test.ts
@@ -149,7 +149,7 @@ describe('mapOtelResourceToMonitoredResource', () => {
       otelAttributes: {
         'cloud.platform': 'gcp_cloud_run',
         'cloud.region': 'myregion',
-        'faas.id': 'myfaasid',
+        'faas.instance': 'myfaasid',
         'faas.name': 'myfaasname',
         'faas.version': 'myfaasversion',
         'service.name': 'servicename',
@@ -163,7 +163,7 @@ describe('mapOtelResourceToMonitoredResource', () => {
       otelAttributes: {
         'cloud.platform': 'gcp_cloud_run',
         'cloud.region': 'myregion',
-        'faas.id': 'myfaasid',
+        'faas.instance': 'myfaasid',
         'faas.name': 'myfaasname',
         'faas.version': 'myfaasversion',
         'service.name': 'servicename',
@@ -177,7 +177,7 @@ describe('mapOtelResourceToMonitoredResource', () => {
       otelAttributes: {
         'cloud.platform': 'gcp_cloud_functions',
         'cloud.region': 'myregion',
-        'faas.id': 'myfaasid',
+        'faas.instance': 'myfaasid',
         'faas.name': 'myfaasname',
         'faas.version': 'myfaasversion',
         'service.name': 'servicename',
@@ -191,7 +191,7 @@ describe('mapOtelResourceToMonitoredResource', () => {
       otelAttributes: {
         'cloud.platform': 'gcp_cloud_functions',
         'cloud.region': 'myregion',
-        'faas.id': 'myfaasid',
+        'faas.instance': 'myfaasid',
         'faas.name': 'myfaasname',
         'faas.version': 'myfaasversion',
         'service.name': 'servicename',
@@ -205,7 +205,7 @@ describe('mapOtelResourceToMonitoredResource', () => {
       otelAttributes: {
         'cloud.platform': 'gcp_app_engine',
         'cloud.region': 'myregion',
-        'faas.id': 'myfaasid',
+        'faas.instance': 'myfaasid',
         'faas.name': 'myfaasname',
         'faas.version': 'myfaasversion',
         'service.name': 'servicename',


### PR DESCRIPTION
Part of https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/679