### PR TITLE
chore: setup Trusted Contribution bot to add /gcbrun on renovate PRs

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -1,0 +1,9 @@
+# Config reference:
+# https://github.com/googleapis/repo-automation-bots/tree/main/packages/trusted-contribution
+
+trustedContributors:
+  - renovate-bot
+annotations:
+  # Automatically run Cloud Build tests
+  - type: comment
+    text: /gcbrun


### PR DESCRIPTION
See trusted contribution app documentation https://github.com/googleapis/repo-automation-bots/tree/main/packages/trusted-contribution. This config will make the bot comment `/gcbrun` on Renovate's PRs so the tests will automatically start.

I just installed the bot on this repo.