### PR TITLE
Use provider.register instead of setGlobalTraceProvider

### DIFF
--- a/samples/trace/index.js
+++ b/samples/trace/index.js
@@ -45,7 +45,7 @@ provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
 
 // Initialize the OpenTelemetry APIs to use the
 // NodeTracerProvider bindings
-opentelemetry.trace.setGlobalTracerProvider(provider);
+provider.register()
 const tracer = opentelemetry.trace.getTracer("basic");
 
 // Create a span.


### PR DESCRIPTION
Calling `provider.register()` calls `setGlobalTracerProvider` and also does some additional tweaking that makes context propagation work properly. Even though this sample doesn't do context propagation, this would save developers headache when they're copying and pasting the setup from this example and wondering why their propagators aren't working with instrumented libraries (which is what happened with me).