### PR TITLE
feat(trace-exporter): use the same resource mapping for metrics and traces

### DIFF
--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -205,7 +205,7 @@ function transformResourceToAttributes(
   resourceFilter?: RegExp,
   stringifyArrayAttributes?: boolean
 ): Attributes {
-  const monitoredResource = mapOtelResourceToMonitoredResource(resource, true);
+  const monitoredResource = mapOtelResourceToMonitoredResource(resource);
   const attributes: ot.SpanAttributes = {};
 
   if (resourceFilter) {

--- a/packages/opentelemetry-resource-util/src/index.ts
+++ b/packages/opentelemetry-resource-util/src/index.ts
@@ -189,13 +189,22 @@ export interface MonitoredResource {
  * https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/v1.8.0/internal/resourcemapping/resourcemapping.go#L51
  *
  * @param resource the OTel Resource
- * @param includeUnsupportedResources if true, will return the most specific monitored resource
- *   possible even if that resource does not support custom metrics. If false, will fallback to
- *   generic resources which support custom metrics. See
- *   https://cloud.google.com/monitoring/custom-metrics for more information on which resources
- *   supporting custom metrics.
  * @returns the corresponding GCM MonitoredResource
  */
+export function mapOtelResourceToMonitoredResource(
+  resource: IResource
+): MonitoredResource;
+/**
+ * @deprecated This overload is deprecated, do not pass the includeUnsupportedResources boolean
+ * parameter. It will be removed in the next major version release.
+ *
+ * @param resource the OTel Resource
+ * @returns the corresponding GCM MonitoredResource
+ */
+export function mapOtelResourceToMonitoredResource(
+  resource: IResource,
+  includeUnsupportedResources: boolean | undefined
+): MonitoredResource;
 export function mapOtelResourceToMonitoredResource(
   resource: IResource,
   includeUnsupportedResources = false


### PR DESCRIPTION
Fixes #553

Deprecate the `includeUnsupportedResources` parameter by splitting the function def into a deprecated and non-deprecated overload. It is no longer needed as we decide that trace and monitoring exporters should do the exact same resource mapping. The package is marked stable so I full removal would be a breaking change.

This is equivalent to what we do in [Go](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/v0.44.0/internal/resourcemapping/resourcemapping.go) and Java https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/pull/250