### PR TITLE
chore(deps): add missing peer dependency to opentelemetry-cloud-trace-exporter

### DIFF
--- a/packages/opentelemetry-cloud-trace-exporter/package.json
+++ b/packages/opentelemetry-cloud-trace-exporter/package.json
@@ -61,6 +61,7 @@
     "@google-cloud/opentelemetry-resource-util": "^2.1.0",
     "@grpc/grpc-js": "^1.1.8",
     "@grpc/proto-loader": "^0.7.0",
+    "@opentelemetry/semantic-conventions": "^1.0.0",
     "google-auth-library": "^9.0.0",
     "google-proto-files": "^4.0.0"
   },


### PR DESCRIPTION
`opentelemetry-resource-util` requests `@opentelemetry/semantic-conventions` as a peer dependency, but `opentelemetry-cloud-trace-exporter` doesn't provide it (unlike `opentelemetry-cloud-monitoring-exporter`).

This results in warnings when installing `opentelemetry-cloud-trace-exporter`:
```
warning "@google-cloud/opentelemetry-cloud-trace-exporter > @google-cloud/opentelemetry-resource-util@2.1.0" has unmet peer dependency "@opentelemetry/semantic-conventions@^1.0.0".
```

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue/feature](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here>