### PR TITLE
fix(resource-detector): map metadata server's instanceID to faas.id instead of faas.instance_id

### DIFF
--- a/packages/opentelemetry-resource-util/src/detector/detector.ts
+++ b/packages/opentelemetry-resource-util/src/detector/detector.ts
@@ -66,37 +66,35 @@ async function gkeResource(): Promise<Resource> {
 }
 
 async function cloudRunResource(): Promise<Resource> {
-  const [faasName, faasVersion, faasInstance, faasCloudRegion] =
-    await Promise.all([
-      faas.faasName(),
-      faas.faasVersion(),
-      faas.faasInstance(),
-      faas.faasCloudRegion(),
-    ]);
+  const [faasName, faasVersion, faasId, faasCloudRegion] = await Promise.all([
+    faas.faasName(),
+    faas.faasVersion(),
+    faas.faasId(),
+    faas.faasCloudRegion(),
+  ]);
 
   return await makeResource({
     [Semconv.CLOUD_PLATFORM]: CloudPlatformValues.GCP_CLOUD_RUN,
     [Semconv.FAAS_NAME]: faasName,
     [Semconv.FAAS_VERSION]: faasVersion,
-    [Semconv.FAAS_INSTANCE]: faasInstance,
+    [Semconv.FAAS_ID]: faasId,
     [Semconv.CLOUD_REGION]: faasCloudRegion,
   });
 }
 
 async function cloudFunctionsResource(): Promise<Resource> {
-  const [faasName, faasVersion, faasInstance, faasCloudRegion] =
-    await Promise.all([
-      faas.faasName(),
-      faas.faasVersion(),
-      faas.faasInstance(),
-      faas.faasCloudRegion(),
-    ]);
+  const [faasName, faasVersion, faasId, faasCloudRegion] = await Promise.all([
+    faas.faasName(),
+    faas.faasVersion(),
+    faas.faasId(),
+    faas.faasCloudRegion(),
+  ]);
 
   return await makeResource({
     [Semconv.CLOUD_PLATFORM]: CloudPlatformValues.GCP_CLOUD_FUNCTIONS,
     [Semconv.FAAS_NAME]: faasName,
     [Semconv.FAAS_VERSION]: faasVersion,
-    [Semconv.FAAS_INSTANCE]: faasInstance,
+    [Semconv.FAAS_ID]: faasId,
     [Semconv.CLOUD_REGION]: faasCloudRegion,
   });
 }
@@ -111,7 +109,7 @@ async function gaeResource(): Promise<Resource> {
   } else {
     ({zone, region} = await gce.availabilityZoneAndRegion());
   }
-  const [faasName, faasVersion, faasInstance] = await Promise.all([
+  const [faasName, faasVersion, faasId] = await Promise.all([
     gae.serviceName(),
     gae.serviceVersion(),
     gae.serviceInstance(),
@@ -121,7 +119,7 @@ async function gaeResource(): Promise<Resource> {
     [Semconv.CLOUD_PLATFORM]: CloudPlatformValues.GCP_APP_ENGINE,
     [Semconv.FAAS_NAME]: faasName,
     [Semconv.FAAS_VERSION]: faasVersion,
-    [Semconv.FAAS_INSTANCE]: faasInstance,
+    [Semconv.FAAS_ID]: faasId,
     [Semconv.CLOUD_AVAILABILITY_ZONE]: zone,
     [Semconv.CLOUD_REGION]: region,
   });

--- a/packages/opentelemetry-resource-util/src/detector/faas.ts
+++ b/packages/opentelemetry-resource-util/src/detector/faas.ts
@@ -55,7 +55,7 @@ export async function faasVersion(): Promise<string> {
  * onCloudRun()} or {@link onCloudFunctions()} is true before calling this, or it may throw
  * exceptions.
  */
-export async function faasInstance(): Promise<string> {
+export async function faasId(): Promise<string> {
   // May be a bignumber.js BigNumber which can just be converted with toString(). See
   // https://github.com/googleapis/gcp-metadata#take-care-with-large-number-valued-properties
   const id = await metadata.instance<number | Object>(ID_METADATA_ATTR);

--- a/packages/opentelemetry-resource-util/test/detector/detector.test.ts
+++ b/packages/opentelemetry-resource-util/test/detector/detector.test.ts
@@ -125,7 +125,7 @@ describe('GcpDetector', () => {
       'cloud.platform': 'gcp_cloud_run',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
-      'faas.instance': '12345',
+      'faas.id': '12345',
       'faas.name': 'fake-service',
       'faas.version': 'fake-revision',
     });
@@ -148,7 +148,7 @@ describe('GcpDetector', () => {
       'cloud.platform': 'gcp_cloud_functions',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
-      'faas.instance': '12345',
+      'faas.id': '12345',
       'faas.name': 'fake-service',
       'faas.version': 'fake-revision',
     });
@@ -171,7 +171,7 @@ describe('GcpDetector', () => {
       'cloud.platform': 'gcp_app_engine',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
-      'faas.instance': 'fake-instance',
+      'faas.id': 'fake-instance',
       'faas.name': 'fake-service',
       'faas.version': 'fake-version',
     });
@@ -192,7 +192,7 @@ describe('GcpDetector', () => {
       'cloud.platform': 'gcp_app_engine',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
-      'faas.instance': 'fake-instance',
+      'faas.id': 'fake-instance',
       'faas.name': 'fake-service',
       'faas.version': 'fake-version',
     });
@@ -320,7 +320,7 @@ describe('GcpDetectorSync', () => {
       'cloud.platform': 'gcp_cloud_run',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
-      'faas.instance': '12345',
+      'faas.id': '12345',
       'faas.name': 'fake-service',
       'faas.version': 'fake-revision',
     });
@@ -344,7 +344,7 @@ describe('GcpDetectorSync', () => {
       'cloud.platform': 'gcp_cloud_functions',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
-      'faas.instance': '12345',
+      'faas.id': '12345',
       'faas.name': 'fake-service',
       'faas.version': 'fake-revision',
     });
@@ -368,7 +368,7 @@ describe('GcpDetectorSync', () => {
       'cloud.platform': 'gcp_app_engine',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
-      'faas.instance': 'fake-instance',
+      'faas.id': 'fake-instance',
       'faas.name': 'fake-service',
       'faas.version': 'fake-version',
     });
@@ -390,7 +390,7 @@ describe('GcpDetectorSync', () => {
       'cloud.platform': 'gcp_app_engine',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
-      'faas.instance': 'fake-instance',
+      'faas.id': 'fake-instance',
       'faas.name': 'fake-service',
       'faas.version': 'fake-version',
     });

--- a/packages/opentelemetry-resource-util/test/detector/faas.test.ts
+++ b/packages/opentelemetry-resource-util/test/detector/faas.test.ts
@@ -67,7 +67,7 @@ describe('FaaS (Cloud Run/Functions)', () => {
     it('as a number', async () => {
       metadataStub.instance.withArgs('id').resolves(12345);
 
-      const faasInstance = await faas.faasInstance();
+      const faasInstance = await faas.faasId();
       assert.strictEqual(faasInstance, '12345');
     });
 
@@ -76,7 +76,7 @@ describe('FaaS (Cloud Run/Functions)', () => {
         .withArgs('id')
         .resolves(new BigNumber('2459451723172637654'));
 
-      const faasInstance = await faas.faasInstance();
+      const faasInstance = await faas.faasId();
       assert.strictEqual(faasInstance, '2459451723172637654');
     });
   });


### PR DESCRIPTION
This matches the current Go/collector impl:
- [`faas.go` in operations-go](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/6b51e22bb5a89706db8e631469b1a491a0a693c3/detectors/gcp/faas.go#L90-L93)
- [`gcp.go` in collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/21ee863aaf7e4d19821927d5108fdf7dd720ec0c/processor/resourcedetectionprocessor/internal/gcp/gcp.go#L83)

This looks like a bug copied from the original Go impl https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/4e508ee3bbb979320283005464642e7d1afd0842/detectors/gcp/faas.go#L59-L62