### PR TITLE
feat(resource-util): use faas resource attributes as fallbacks for service.* attributes

### DIFF
--- a/packages/opentelemetry-resource-util/__snapshots__/index.test.ts.js
+++ b/packages/opentelemetry-resource-util/__snapshots__/index.test.ts.js
@@ -2,7 +2,7 @@ exports['mapOtelResourceToMonitoredResource should map cloud_function to generic
   "type": "generic_task",
   "labels": {
     "location": "myregion",
-    "namespace": "",
+    "namespace": "servicens",
     "job": "servicename",
     "task_id": "serviceinstanceid"
   }
@@ -12,7 +12,7 @@ exports['mapOtelResourceToMonitoredResource should map cloud_run_revision to gen
   "type": "generic_task",
   "labels": {
     "location": "myregion",
-    "namespace": "",
+    "namespace": "servicens",
     "job": "servicename",
     "task_id": "serviceinstanceid"
   }
@@ -69,7 +69,7 @@ exports['mapOtelResourceToMonitoredResource should map to gae_instance" 1'] = {
     "location": "myregion",
     "module_id": "myfaasname",
     "version_id": "myfaasversion",
-    "instance_id": "myfaasid"
+    "instance_id": "myfaasinstance"
   }
 }
 
@@ -127,6 +127,36 @@ exports['mapOtelResourceToMonitoredResource should map to generic_task 1'] = {
   }
 }
 
+exports['mapOtelResourceToMonitoredResource should map to generic_task with fallback to faas.instance 1'] = {
+  "type": "generic_task",
+  "labels": {
+    "location": "myavailzone",
+    "namespace": "servicens",
+    "job": "servicename",
+    "task_id": "myfaasinstance"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to generic_task with fallback to faas.name 1'] = {
+  "type": "generic_task",
+  "labels": {
+    "location": "myavailzone",
+    "namespace": "servicens",
+    "job": "myfaasname",
+    "task_id": "serviceinstanceid"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to generic_task with fallback to faas.name if service.name="unknown_service*" 1'] = {
+  "type": "generic_task",
+  "labels": {
+    "location": "myregion",
+    "namespace": "servicens",
+    "job": "myfaasname",
+    "task_id": "myfaasinstance"
+  }
+}
+
 exports['mapOtelResourceToMonitoredResource should map to generic_task with fallback to global 1'] = {
   "type": "generic_task",
   "labels": {
@@ -143,6 +173,16 @@ exports['mapOtelResourceToMonitoredResource should map to generic_task with fall
     "location": "myregion",
     "namespace": "servicens",
     "job": "servicename",
+    "task_id": "serviceinstanceid"
+  }
+}
+
+exports['mapOtelResourceToMonitoredResource should map to generic_task with unknown_service* if no better match found 1'] = {
+  "type": "generic_task",
+  "labels": {
+    "location": "myavailzone",
+    "namespace": "servicens",
+    "job": "unknown_service:node",
     "task_id": "serviceinstanceid"
   }
 }

--- a/packages/opentelemetry-resource-util/test/index.test.ts
+++ b/packages/opentelemetry-resource-util/test/index.test.ts
@@ -149,7 +149,7 @@ describe('mapOtelResourceToMonitoredResource', () => {
       otelAttributes: {
         'cloud.platform': 'gcp_cloud_run',
         'cloud.region': 'myregion',
-        'faas.instance': 'myfaasid',
+        'faas.instance': 'myfaasinstance',
         'faas.name': 'myfaasname',
         'faas.version': 'myfaasversion',
         'service.name': 'servicename',
@@ -163,10 +163,11 @@ describe('mapOtelResourceToMonitoredResource', () => {
       otelAttributes: {
         'cloud.platform': 'gcp_cloud_run',
         'cloud.region': 'myregion',
-        'faas.instance': 'myfaasid',
+        'faas.instance': 'myfaasinstance',
         'faas.name': 'myfaasname',
         'faas.version': 'myfaasversion',
         'service.name': 'servicename',
+        'service.namespace': 'servicens',
         'service.instance.id': 'serviceinstanceid',
       },
       includeUnsupportedResources: false,
@@ -177,7 +178,7 @@ describe('mapOtelResourceToMonitoredResource', () => {
       otelAttributes: {
         'cloud.platform': 'gcp_cloud_functions',
         'cloud.region': 'myregion',
-        'faas.instance': 'myfaasid',
+        'faas.instance': 'myfaasinstance',
         'faas.name': 'myfaasname',
         'faas.version': 'myfaasversion',
         'service.name': 'servicename',
@@ -191,10 +192,11 @@ describe('mapOtelResourceToMonitoredResource', () => {
       otelAttributes: {
         'cloud.platform': 'gcp_cloud_functions',
         'cloud.region': 'myregion',
-        'faas.instance': 'myfaasid',
+        'faas.instance': 'myfaasinstance',
         'faas.name': 'myfaasname',
         'faas.version': 'myfaasversion',
         'service.name': 'servicename',
+        'service.namespace': 'servicens',
         'service.instance.id': 'serviceinstanceid',
       },
       includeUnsupportedResources: false,
@@ -205,7 +207,7 @@ describe('mapOtelResourceToMonitoredResource', () => {
       otelAttributes: {
         'cloud.platform': 'gcp_app_engine',
         'cloud.region': 'myregion',
-        'faas.instance': 'myfaasid',
+        'faas.instance': 'myfaasinstance',
         'faas.name': 'myfaasname',
         'faas.version': 'myfaasversion',
         'service.name': 'servicename',
@@ -219,6 +221,16 @@ describe('mapOtelResourceToMonitoredResource', () => {
         'cloud.availability_zone': 'myavailzone',
         'service.namespace': 'servicens',
         'service.name': 'servicename',
+        'service.instance.id': 'serviceinstanceid',
+      },
+    },
+    {
+      title:
+        'should map to generic_task with unknown_service* if no better match found',
+      otelAttributes: {
+        'cloud.availability_zone': 'myavailzone',
+        'service.namespace': 'servicens',
+        'service.name': 'unknown_service:node',
         'service.instance.id': 'serviceinstanceid',
       },
     },
@@ -239,6 +251,36 @@ describe('mapOtelResourceToMonitoredResource', () => {
         'service.namespace': 'servicens',
         'service.name': 'servicename',
         'service.instance.id': 'serviceinstanceid',
+      },
+    },
+
+    {
+      title: 'should map to generic_task with fallback to faas.name',
+      otelAttributes: {
+        'cloud.availability_zone': 'myavailzone',
+        'service.namespace': 'servicens',
+        'service.instance.id': 'serviceinstanceid',
+        'faas.name': 'myfaasname',
+      },
+    },
+    {
+      title:
+        'should map to generic_task with fallback to faas.name if service.name="unknown_service*"',
+      otelAttributes: {
+        'cloud.region': 'myregion',
+        'faas.instance': 'myfaasinstance',
+        'faas.name': 'myfaasname',
+        'service.name': 'unknown_service:foo',
+        'service.namespace': 'servicens',
+      },
+    },
+    {
+      title: 'should map to generic_task with fallback to faas.instance',
+      otelAttributes: {
+        'cloud.availability_zone': 'myavailzone',
+        'service.namespace': 'servicens',
+        'service.name': 'servicename',
+        'faas.instance': 'myfaasinstance',
       },
     },
 


### PR DESCRIPTION
Fixes #641

Pretty much copied from https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/273