### PR TITLE
chore: remove SimpleSpanProcessor from README and sample

### DIFF
--- a/packages/opentelemetry-cloud-trace-exporter/README.md
+++ b/packages/opentelemetry-cloud-trace-exporter/README.md
@@ -28,16 +28,13 @@ const exporter = new TraceExporter({
 });
 ```
 
-Now, register the exporter.
+Now, register the exporter with the built-in
+[`BatchSpanProcessor`](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.4.0/specification/trace/sdk.md#batching-processor)
+which batches ended spans and passes them to the configured `SpanExporter`.
 
 ```js
 provider.addSpanProcessor(new BatchSpanProcessor(exporter));
 ```
-
-You can use built-in `SimpleSpanProcessor` or `BatchSpanProcessor` or write your own.
-
-- [SimpleSpanProcessor](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.4.0/specification/trace/sdk.md#simple-processor): The implementation of `SpanProcessor` that passes ended span directly to the configured `SpanExporter`.
-- [BatchSpanProcessor](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.4.0/specification/trace/sdk.md#batching-processor): The implementation of the `SpanProcessor` that batches ended spans and pushes them to the configured `SpanExporter`. It is recommended to use this `SpanProcessor` for better performance and optimization.
 
 ## Resource attributes
 

--- a/samples/trace/index.js
+++ b/samples/trace/index.js
@@ -19,7 +19,7 @@
 // [START opentelemetry_trace_import]
 const opentelemetry = require("@opentelemetry/api");
 const { NodeTracerProvider } = require("@opentelemetry/sdk-trace-node");
-const { SimpleSpanProcessor } = require("@opentelemetry/sdk-trace-base");
+const { BatchSpanProcessor } = require("@opentelemetry/sdk-trace-base");
 const {
   TraceExporter,
 } = require("@google-cloud/opentelemetry-cloud-trace-exporter");
@@ -36,8 +36,8 @@ const provider = new NodeTracerProvider();
 // you don't need to provide auth credentials or a project id.
 const exporter = new TraceExporter();
 
-// Configure the span processor to send spans to the exporter
-provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+// Configure the span processor to batch and send spans to the exporter
+provider.addSpanProcessor(new BatchSpanProcessor(exporter));
 
 // [END setup_exporter]
 
@@ -45,7 +45,7 @@ provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
 
 // Initialize the OpenTelemetry APIs to use the
 // NodeTracerProvider bindings
-provider.register()
+provider.register();
 const tracer = opentelemetry.trace.getTracer("basic");
 
 // Create a span.
@@ -66,4 +66,13 @@ span.end();
 
 console.log("Done recording traces.");
 
+// Finally shutdown the NodeTracerProvider to finish flushing any batched spans
+provider.shutdown().then(
+  () => {
+    console.log("Successfully shutdown");
+  },
+  (err) => {
+    console.error("Error shutting down", err);
+  }
+);
 // [END opentelemetry_trace_samples]


### PR DESCRIPTION
We don't ever recommend using `SimpleSpanProcessor` because of poor performance and large number of API requests. Remove it from our sample (which goes to [this doc](https://cloud.google.com/trace/docs/setup/nodejs-ot#gke)) and README