### PR TITLE
docs: added a few fixes for the quickstart sample

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,10 @@
     {
       "matchPackagePrefixes": ["@nx/", "nx"],
       "groupName": "nx"
+    },
+    {
+      "matchPackageNames": ["fastify"],
+      "groupName": "fastify"
     }
   ]
 }

--- a/samples/instrumentation-quickstart/package-lock.json
+++ b/samples/instrumentation-quickstart/package-lock.json
@@ -15,7 +15,7 @@
         "@opentelemetry/sdk-metrics": "1.22.0",
         "@opentelemetry/sdk-node": "0.49.1",
         "axios": "1.6.8",
-        "fastify": "4.26.2",
+        "fastify": "4.23.2",
         "pino": "8.19.0"
       },
       "devDependencies": {
@@ -252,9 +252,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.3.tgz",
-      "integrity": "sha512-qiO9MNgYnwbvZ8MK0YLWbnGrNX3zTcj6/Ef7UHu5ZofER3e2nF3Y35GaPo9qNJJ/UJQKa4KL+z/F4Q8Q+uCdUQ==",
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.6.tgz",
+      "integrity": "sha512-xP58G7wDQ4TCmN/cMUHh00DS7SRDv/+lC+xFLrTkMIN8h55X5NhZMLYbvy7dSELP15qlI6hPhNCRWVMtZMwqLA==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.10",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -264,9 +264,9 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.10.tgz",
-      "integrity": "sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==",
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.12.tgz",
+      "integrity": "sha512-DCVwMxqYzpUCiDMl7hQ384FqP4T3DbNpXU8pt681l3UWCip1WUiD5JrkImUwCB9a7f2cq4CUTmi5r/xIMRPY1Q==",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -392,9 +392,9 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
-      "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "dev": true
     },
     "node_modules/@js-sdsl/ordered-map": {
@@ -560,6 +560,21 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
       "version": "0.49.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.49.1.tgz",
@@ -578,6 +593,21 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
@@ -599,6 +629,21 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/resources": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
       "version": "0.49.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.49.1.tgz",
@@ -615,6 +660,21 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
@@ -636,6 +696,21 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
     "node_modules/@opentelemetry/exporter-zipkin": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.22.0.tgz",
@@ -651,6 +726,21 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/resources": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
@@ -1322,10 +1412,25 @@
         "@opentelemetry/api": ">=1.3.0 <1.9.0"
       }
     },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
     "node_modules/@opentelemetry/propagation-utils": {
-      "version": "0.30.7",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.7.tgz",
-      "integrity": "sha512-QkxOkuCQdq8YgJstEMF4ntSyr0ivCrcQc49uvO2pyccrniu2DwA+JD071aM4BXfNVSCeOuhIyW/3QPiZYl4zdA==",
+      "version": "0.30.8",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.8.tgz",
+      "integrity": "sha512-ZKjsUm//SvL8I9JS+bJpAXGpe0Fb+sO+AiWS0fb7EKKLEm3GoNAO7CDMs8GMZBZ91ElR3tBjdUKf/9MzUdYHBA==",
       "engines": {
         "node": ">=14"
       },
@@ -1384,12 +1489,12 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-alibaba-cloud": {
-      "version": "0.28.7",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.28.7.tgz",
-      "integrity": "sha512-7o/waBJ08JrKED4blHGyBPIN1HMM1KEvhbO1HmdA+tsUqsGwZdTjsdMKFW7hc1TvAu4AQEnuvMy/Q5OByVr95A==",
+      "version": "0.28.8",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.28.8.tgz",
+      "integrity": "sha512-njdK7S90OX99H0nlDh45vmGU3Bn46JSNjciU18NefyU6R3Dq5ZUU13DWxSlrCBWAiH/+SFJyHQMFsXRnTOFp6w==",
       "dependencies": {
         "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -1399,13 +1504,13 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-aws": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.4.0.tgz",
-      "integrity": "sha512-Cn8eQ/heLqrNrPuHGG7xUkk//VQt4hzVIPurmLlCI0wrDV6HR+yykBvRkJBuSdLzbjeQ/qNbGel9OvTmA6PBQA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.4.1.tgz",
+      "integrity": "sha512-QsPJwXDxlt+IWQazST7renk9KDOAK3hsywb0Mw6gEwgEoe12EvdVcT+mCknTc+hu5WzxiTmFMtnn1TWab7To1g==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -1415,12 +1520,12 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-container": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.3.7.tgz",
-      "integrity": "sha512-AYqwffGVuGLuzzVOQMLNHTztwyvsep9noxN9HTQ/grwmJSWZ6851kNx+W735K7v6GZEDmXeLpBn+J3TeqKQUJA==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.3.8.tgz",
+      "integrity": "sha512-YusLYSo8Rr1yKEhakaJ2XgbfbLses5t8YsSRHhO0b6SLliZOFq9ymxoWgtuwyabNCqMMJJYuvrE3Nq0AL6sbcQ==",
       "dependencies": {
         "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -1430,9 +1535,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-gcp": {
-      "version": "0.29.7",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.7.tgz",
-      "integrity": "sha512-uUHKfoOgBCZCEPCU6FWnRrbYuz1miaeIfos0Xe38YuR06vQvddhqZ0tewYunJpfECfKEcjSjY0eDe2QIRLMkXw==",
+      "version": "0.29.8",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.29.8.tgz",
+      "integrity": "sha512-jvFtsnrQI7CLDxehp6BxtudbZ3a0HZ+Dj/vFy251280efc15gQdlvFUqXbKBw6ODt/3o38ilw8e0qePJbm2eAg==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
@@ -1447,18 +1552,40 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
-      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
+      "integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.23.0.tgz",
+      "integrity": "sha512-MiqFvfOzfR31t8cc74CTP1OZfz7MbqpAnLCra8NqQoaHJX6ncIRTdYOQYBDQ2uFISDq0WY8Y9dDTWvsgzzBYRg==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
@@ -1477,6 +1604,21 @@
         "@opentelemetry/api-logs": ">=0.39.1"
       }
     },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
     "node_modules/@opentelemetry/sdk-metrics": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.22.0.tgz",
@@ -1491,6 +1633,21 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
@@ -1519,6 +1676,21 @@
         "@opentelemetry/api": ">=1.3.0 <1.9.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/resources": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.22.0.tgz",
@@ -1526,6 +1698,21 @@
       "dependencies": {
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "dependencies": {
+        "@opentelemetry/core": "1.22.0",
         "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "engines": {
@@ -1726,9 +1913,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.43",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.43.tgz",
-      "integrity": "sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.0.tgz",
+      "integrity": "sha512-bGyep3JqPCRry1wq+O5n7oiBgGWmeIJXPjXXCo8EK0u8duZGSYar7cGqd3ML2JUsLGeB7fmc06KYo9fLGWqPvQ==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1920,13 +2107,13 @@
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
-      "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
       "dependencies": {
         "@types/http-errors": "*",
-        "@types/mime": "*",
-        "@types/node": "*"
+        "@types/node": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/shimmer": {
@@ -2181,9 +2368,9 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -3117,17 +3304,33 @@
       "dev": true
     },
     "node_modules/fast-json-stringify": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.13.0.tgz",
-      "integrity": "sha512-XjTDWKHP3GoMQUOfnjYUbqeHeEt+PvYgvBdG2fRSmYaORILbSr8xTJvZX+w1YSAP5pw2NwKrGRmQleYueZEoxw==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.14.0.tgz",
+      "integrity": "sha512-6m9a2JN9kDFMADmP9MHLbLPrFu5oSSfrwFLzpcqt/aFgcEi+SVhTJGsx/Wivlls8fQ3OnP8UDNfIY1d1qCC50w==",
       "dependencies": {
         "@fastify/merge-json-schemas": "^0.1.0",
         "ajv": "^8.10.0",
-        "ajv-formats": "^2.1.1",
+        "ajv-formats": "^3.0.1",
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^2.1.0",
         "json-schema-ref-resolver": "^1.0.1",
         "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/fast-levenshtein": {
@@ -3158,36 +3361,26 @@
       "integrity": "sha512-eel5UKGn369gGEWOqBShmFJWfq/xSJvsgDzgLYC845GneayWvXBf0lJCBn5qTABfewy1ZDPoaR5OZCP+kssfuw=="
     },
     "node_modules/fastify": {
-      "version": "4.26.2",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.26.2.tgz",
-      "integrity": "sha512-90pjTuPGrfVKtdpLeLzND5nyC4woXZN5VadiNQCicj/iJU4viNHKhsAnb7jmv1vu2IzkLXyBiCzdWuzeXgQ5Ug==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.23.2.tgz",
+      "integrity": "sha512-WFSxsHES115svC7NrerNqZwwM0UOxbC/P6toT9LRHgAAFvG7o2AN5W+H4ihCtOGuYXjZf4z+2jXC89rVEoPWOA==",
       "dependencies": {
         "@fastify/ajv-compiler": "^3.5.0",
-        "@fastify/error": "^3.4.0",
+        "@fastify/error": "^3.2.0",
         "@fastify/fast-json-stringify-compiler": "^4.3.0",
         "abstract-logging": "^2.0.1",
-        "avvio": "^8.3.0",
-        "fast-content-type-parse": "^1.1.0",
-        "fast-json-stringify": "^5.8.0",
-        "find-my-way": "^8.0.0",
-        "light-my-request": "^5.11.0",
-        "pino": "^8.17.0",
-        "process-warning": "^3.0.0",
+        "avvio": "^8.2.1",
+        "fast-content-type-parse": "^1.0.0",
+        "fast-json-stringify": "^5.7.0",
+        "find-my-way": "^7.6.0",
+        "light-my-request": "^5.9.1",
+        "pino": "^8.12.0",
+        "process-warning": "^2.2.0",
         "proxy-addr": "^2.0.7",
         "rfdc": "^1.3.0",
-        "secure-json-parse": "^2.7.0",
-        "semver": "^7.5.4",
-        "toad-cache": "^3.3.0"
+        "secure-json-parse": "^2.5.0",
+        "semver": "^7.5.0",
+        "toad-cache": "^3.2.0"
       }
     },
     "node_modules/fastq": {
@@ -3247,9 +3440,9 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.1.0.tgz",
-      "integrity": "sha512-41QwjCGcVTODUmLLqTMeoHeiozbMXYMAE1CKFiDyi9zVZ2Vjh0yz3MF0WQZoIb+cmzP/XlbFjlF2NtJmvZHznA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.7.0.tgz",
+      "integrity": "sha512-+SrHpvQ52Q6W9f3wJoJBbAQULJuNEEQwBvlvYwACDhBTLOTMiQ0HYWh4+vC3OivGP2ENcTI1oKlFA2OepJNjhQ==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-querystring": "^1.0.0",
@@ -3350,14 +3543,15 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.3.0.tgz",
-      "integrity": "sha512-p+ggrQw3fBwH2F5N/PAI4k/G/y1art5OxKpb2J2chwNNHM4hHuAOtivjPuirMF4KNKwTTUal/lPfL2+7h2mEcg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.4.0.tgz",
+      "integrity": "sha512-apAloYrY4dlBGlhauDAYSZveafb5U6+L9titing1wox6BvWM0TSXBp603zTrLpyLMGkrcFgohnUN150dFN/zOA==",
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
         "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9"
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=14"
@@ -3786,9 +3980,9 @@
       "dev": true
     },
     "node_modules/joi": {
-      "version": "17.12.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.2.tgz",
-      "integrity": "sha512-RonXAIzCiHLc8ss3Ibuz45u28GOsWE1UpfDXLbN/9NKbL4tCJf8TWYVKsoYuuh+sAUt7fsSNpA+r2+TBA6Wjmw==",
+      "version": "17.12.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.3.tgz",
+      "integrity": "sha512-2RRziagf555owrm9IRVtdKynOBeITiDpuZqIpgwqXShPncPKNiRQoiGsl/T8SQdq+8ugRzH2LqY67irr2y/d+g==",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
         "@hapi/topo": "^5.1.0",
@@ -3906,6 +4100,11 @@
         "process-warning": "^3.0.0",
         "set-cookie-parser": "^2.4.1"
       }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -4361,9 +4560,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
-      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
+      "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg=="
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
@@ -4432,6 +4631,11 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
       "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+    },
+    "node_modules/pino/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
@@ -4513,9 +4717,9 @@
       }
     },
     "node_modules/process-warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
-      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.3.2.tgz",
+      "integrity": "sha512-n9wh8tvBe5sFmsqlg+XQhaQLumwpqoAUruLwjCopgTmUBjJ/fjtBsJzKleCaIGBOMXYEhp1YfKl4d7rJ5ZKJGA=="
     },
     "node_modules/protobufjs": {
       "version": "7.2.6",
@@ -4793,9 +4997,9 @@
       }
     },
     "node_modules/require-in-the-middle": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.1.tgz",
-      "integrity": "sha512-u5XngygsJ+XV2dBV/Pl4SrcNpUXQfmYmXtuFeHDXfzk4i4NnGnret6xKWkkJHjMHS/16yMV9pEAlAunqmjllkA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.3.0.tgz",
+      "integrity": "sha512-nQFEv9gRw6SJAwWD2LrL0NmQvAcO7FBwJbwmr2ttPAacfy0xuiOjE5zt+zM4xDyuyvUaxBi/9gb2SoCyNEVJcw==",
       "dependencies": {
         "debug": "^4.1.1",
         "module-details-from-path": "^1.0.3",
@@ -5031,9 +5235,9 @@
       }
     },
     "node_modules/sonic-boom": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.0.tgz",
-      "integrity": "sha512-ybz6OYOUjoQQCQ/i4LU8kaToD8ACtYP+Cj5qd2AO36bwbdewxWJ3ArmJ2cr6AvxlL2o0PqnCcPGUgkILbfkaCA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
@@ -5318,6 +5522,18 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/samples/instrumentation-quickstart/package.json
+++ b/samples/instrumentation-quickstart/package.json
@@ -33,7 +33,7 @@
     "@opentelemetry/sdk-metrics": "1.22.0",
     "@opentelemetry/sdk-node": "0.49.1",
     "axios": "1.6.8",
-    "fastify": "4.26.2",
+    "fastify": "4.23.2",
     "pino": "8.19.0"
   }
 }

--- a/samples/instrumentation-quickstart/src/index.ts
+++ b/samples/instrumentation-quickstart/src/index.ts
@@ -44,11 +44,11 @@ fastify.get('/single', async request => {
  * handleMulti handles an http request by making 3-7 http requests to the /single endpoint.
  *
  * OpenTelemetry instrumentation requires no changes here. It will automatically generate a
- * span for the controller body.
+ * span for the handler body.
  */
 fastify.get('/multi', async request => {
   const subRequests = randInt(3, 8);
-  request.log.info({subRequests}, 'handle /multi request', subRequests);
+  request.log.info({subRequests}, 'handle /multi request');
 
   for (let i = 0; i < subRequests; i++) {
     await axios.get(`http://localhost:${port}/single`);


### PR DESCRIPTION
- Downgrade fastify to 4.23.2 as that is the last version supporting Typescript v4. This was accidentally upgraded in https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/pull/689
- Add a renovate rule to split out fastify upgrades since it can't be upgraded right now
- Small tweaks to comments and logging code