### PR TITLE
docs(instrumentation-quickstart): fix collector severity parsing to match Cloud Logging agent

### DIFF
--- a/samples/instrumentation-quickstart/otel-collector-config.yaml
+++ b/samples/instrumentation-quickstart/otel-collector-config.yaml
@@ -34,6 +34,18 @@ receivers:
           layout: '%Y-%m-%dT%H:%M:%S.%fZ'
         severity:
           parse_from: body.severity
+          preset: none
+          # parse minimal set of severity strings that Cloud Logging explicitly supports
+          # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
+          mapping:
+            debug: debug
+            info: info
+            info3: notice
+            warn: warning
+            error: error
+            fatal: critical
+            fatal3: alert
+            fatal4: emergency
 
       # set trace_flags to SAMPLED if GCP attribute is set to true
       - type: add


### PR DESCRIPTION
Similar to https://github.com/GoogleCloudPlatform/golang-samples/pull/3999, this makes the collector parse severity strings the same way the Cloud Logging agent does. The app already outputs the correct severity strings.

Tested manually by logging at various levels 
![image](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/assets/1510004/911812ad-904e-4d98-890f-c8963d77c05f)
