### PR TITLE
feat: Add sample for otlp-trace export via grpc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3783,7 +3783,6 @@
       "version": "1.6.8",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
       "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
-      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -6212,7 +6211,6 @@
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
       "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -6253,7 +6251,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -11541,8 +11538,7 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -15883,6 +15879,7 @@
         "@opentelemetry/resources": "1.22.0",
         "@opentelemetry/sdk-node": "0.49.1",
         "@opentelemetry/semantic-conventions": "1.22.0",
+        "axios": "^1.6.8",
         "express": "4.19.2",
         "google-auth-library": "9.7.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12502,6 +12502,10 @@
       "resolved": "samples/otlptracehttp",
       "link": true
     },
+    "node_modules/sample-app-grpc": {
+      "resolved": "samples/otlptracegrpc",
+      "link": true
+    },
     "node_modules/semver": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
@@ -15867,6 +15871,20 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "samples/otlptracegrpc": {
+      "name": "sample-app-grpc",
+      "version": "0.1.0",
+      "license": "ISC",
+      "dependencies": {
+        "@opentelemetry/api": "1.8.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-node": "0.49.1",
+        "@opentelemetry/semantic-conventions": "1.22.0",
+        "express": "4.19.2",
+        "google-auth-library": "9.7.0"
       }
     },
     "samples/otlptracehttp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15876,7 +15876,7 @@
     "samples/otlptracegrpc": {
       "name": "sample-app-grpc",
       "version": "0.1.0",
-      "license": "ISC",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.8.0",
         "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
@@ -15885,6 +15885,9 @@
         "@opentelemetry/semantic-conventions": "1.22.0",
         "express": "4.19.2",
         "google-auth-library": "9.7.0"
+      },
+      "devDependencies": {
+        "gts": "^5.3.0"
       }
     },
     "samples/otlptracehttp": {

--- a/samples/otlptracegrpc/.prettierrc.js
+++ b/samples/otlptracegrpc/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ...require('gts/.prettierrc.json')
+}

--- a/samples/otlptracegrpc/.prettierrc.js
+++ b/samples/otlptracegrpc/.prettierrc.js
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 module.exports = {
   ...require('gts/.prettierrc.json')
 }

--- a/samples/otlptracegrpc/README.md
+++ b/samples/otlptracegrpc/README.md
@@ -17,7 +17,7 @@ export OTEL_RESOURCE_ATTRIBUTES="gcp.project_id=<project-id>"
 export OTEL_EXPORTER_OTLP_ENDPOINT=<endpoint>
 
 # run the app - this starts app at port 8080
-cd samples/otlptracegrpc && ts-node app.ts
+cd samples/otlptracegrpc && npm run start
 ```
 
 ## Sending Requests to the Application

--- a/samples/otlptracegrpc/README.md
+++ b/samples/otlptracegrpc/README.md
@@ -1,0 +1,37 @@
+# Overview
+
+This example shows how to send traces to an OTLP *(OpenTelemetry Protocol)* endpoint that is protected by GCP authentication over gRPC.
+
+## Installation
+
+```sh
+# from root of repo, build all packages
+npm install
+```
+
+## Run the Application
+
+```sh
+# export necessary OTEL environment variables
+export OTEL_RESOURCE_ATTRIBUTES="gcp.project_id=<project-id>"
+export OTEL_EXPORTER_OTLP_ENDPOINT=<endpoint>
+
+# run the app - this starts app at port 8080
+cd samples/otlptracehttp && ts-node app.ts
+```
+
+## Sending Requests to the Application
+
+In another terminal window:
+
+```sh
+curl localhost:8080/rolldice?rolls=12
+```
+
+## Useful links
+- For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
+- For more information on tracing, visit: <https://opentelemetry.io/docs/concepts/signals/traces/>
+
+## LICENSE
+
+Apache License 2.0

--- a/samples/otlptracegrpc/README.md
+++ b/samples/otlptracegrpc/README.md
@@ -17,7 +17,7 @@ export OTEL_RESOURCE_ATTRIBUTES="gcp.project_id=<project-id>"
 export OTEL_EXPORTER_OTLP_ENDPOINT=<endpoint>
 
 # run the app - this starts app at port 8080
-cd samples/otlptracehttp && ts-node app.ts
+cd samples/otlptracegrpc && ts-node app.ts
 ```
 
 ## Sending Requests to the Application

--- a/samples/otlptracegrpc/README.md
+++ b/samples/otlptracegrpc/README.md
@@ -24,8 +24,14 @@ cd samples/otlptracegrpc && npm run start
 
 In another terminal window:
 
+To send a one-off request:
 ```sh
 curl localhost:8080/rolldice?rolls=12
+```
+
+To send requests indefinitely at a fixed rate, use the provided client application:
+```sh
+npm run client
 ```
 
 ## Useful links

--- a/samples/otlptracegrpc/app.ts
+++ b/samples/otlptracegrpc/app.ts
@@ -13,16 +13,14 @@
 // limitations under the License.
 //
 
-import { trace, diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
-import express, { Express, Request, Response } from 'express';
-import { rollTheDice } from './dice';
+import {diag, DiagConsoleLogger, DiagLogLevel} from '@opentelemetry/api';
+import express, {Express, Request, Response} from 'express';
+import {rollTheDice} from './dice';
 
-import { NodeSDK } from '@opentelemetry/sdk-node';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
-import { AuthClient, GoogleAuth } from 'google-auth-library';
-import { credentials } from '@grpc/grpc-js';
-
-const tracer = trace.getTracer('dice-server', '0.1.0');
+import {NodeSDK} from '@opentelemetry/sdk-node';
+import {OTLPTraceExporter} from '@opentelemetry/exporter-trace-otlp-grpc';
+import {AuthClient, GoogleAuth} from 'google-auth-library';
+import {credentials} from '@grpc/grpc-js';
 
 const PORT: number = parseInt(process.env.PORT || '8080');
 const app: Express = express();
@@ -30,18 +28,21 @@ const app: Express = express();
 async function main() {
   diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
 
-  async function getAuthenticatedClient(): Promise<AuthClient> {  
+  async function getAuthenticatedClient(): Promise<AuthClient> {
     const auth: GoogleAuth = new GoogleAuth({
       scopes: 'https://www.googleapis.com/auth/cloud-platform',
     });
     const client: AuthClient = await auth.getClient();
-    return client;    
+    return client;
   }
   const authenticatedClient: AuthClient = await getAuthenticatedClient();
 
   const sdk = new NodeSDK({
     traceExporter: new OTLPTraceExporter({
-      credentials: credentials.combineChannelCredentials(credentials.createSsl(), credentials.createFromGoogleCredential(authenticatedClient)),
+      credentials: credentials.combineChannelCredentials(
+        credentials.createSsl(),
+        credentials.createFromGoogleCredential(authenticatedClient)
+      ),
     }),
   });
   sdk.start();
@@ -50,8 +51,8 @@ async function main() {
     const rolls = req.query.rolls ? parseInt(req.query.rolls.toString()) : NaN;
     if (isNaN(rolls)) {
       res
-          .status(400)
-          .send("Request parameter 'rolls' is missing or not a number.");
+        .status(400)
+        .send("Request parameter 'rolls' is missing or not a number.");
       return;
     }
     res.send(JSON.stringify(rollTheDice(rolls, 1, 6)));

--- a/samples/otlptracegrpc/app.ts
+++ b/samples/otlptracegrpc/app.ts
@@ -15,21 +15,22 @@
 //
 
 /*app.ts*/
-import { trace } from '@opentelemetry/api';
+import { trace, diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
 import express, { Express, Request, Response } from 'express';
 import { rollTheDice } from './dice';
+
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
+import { AuthClient, GoogleAuth } from 'google-auth-library';
+import { Headers } from 'google-auth-library/build/src/auth/oauth2client';
 
 const tracer = trace.getTracer('dice-server', '0.1.0');
 
 const PORT: number = parseInt(process.env.PORT || '8080');
 const app: Express = express();
 
-import {NodeSDK} from '@opentelemetry/sdk-node';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
-import { AuthClient, GoogleAuth } from 'google-auth-library';
-import { Headers } from 'google-auth-library/build/src/auth/oauth2client';
-
 async function main() {
+  diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
   async function getAuthenticatedClient(): Promise<AuthClient> {  
     const auth: GoogleAuth = new GoogleAuth({
       scopes: 'https://www.googleapis.com/auth/cloud-platform',

--- a/samples/otlptracegrpc/app.ts
+++ b/samples/otlptracegrpc/app.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 //
 
-/*app.ts*/
 import { trace, diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
 import express, { Express, Request, Response } from 'express';
 import { rollTheDice } from './dice';

--- a/samples/otlptracegrpc/app.ts
+++ b/samples/otlptracegrpc/app.ts
@@ -23,14 +23,14 @@ import {credentials} from '@grpc/grpc-js';
 const PORT: number = parseInt(process.env.PORT || '8080');
 const app: Express = express();
 
+async function getAuthenticatedClient(): Promise<AuthClient> {
+  const auth: GoogleAuth = new GoogleAuth({
+    scopes: 'https://www.googleapis.com/auth/cloud-platform',
+  });
+  return await auth.getClient();
+}
+
 async function main() {
-  async function getAuthenticatedClient(): Promise<AuthClient> {
-    const auth: GoogleAuth = new GoogleAuth({
-      scopes: 'https://www.googleapis.com/auth/cloud-platform',
-    });
-    const client: AuthClient = await auth.getClient();
-    return client;
-  }
   const authenticatedClient: AuthClient = await getAuthenticatedClient();
 
   const sdk = new NodeSDK({

--- a/samples/otlptracegrpc/app.ts
+++ b/samples/otlptracegrpc/app.ts
@@ -1,4 +1,3 @@
-// Copyright OpenTelemetry Authors
 // Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/samples/otlptracegrpc/app.ts
+++ b/samples/otlptracegrpc/app.ts
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-
-import {diag, DiagConsoleLogger, DiagLogLevel} from '@opentelemetry/api';
 import express, {Express, Request, Response} from 'express';
 import {rollTheDice} from './dice';
 
@@ -26,8 +24,6 @@ const PORT: number = parseInt(process.env.PORT || '8080');
 const app: Express = express();
 
 async function main() {
-  diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
-
   async function getAuthenticatedClient(): Promise<AuthClient> {
     const auth: GoogleAuth = new GoogleAuth({
       scopes: 'https://www.googleapis.com/auth/cloud-platform',

--- a/samples/otlptracegrpc/app.ts
+++ b/samples/otlptracegrpc/app.ts
@@ -1,0 +1,67 @@
+// Copyright OpenTelemetry Authors
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/*app.ts*/
+import { trace } from '@opentelemetry/api';
+import express, { Express, Request, Response } from 'express';
+import { rollTheDice } from './dice';
+
+const tracer = trace.getTracer('dice-server', '0.1.0');
+
+const PORT: number = parseInt(process.env.PORT || '8080');
+const app: Express = express();
+
+import {NodeSDK} from '@opentelemetry/sdk-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
+import { AuthClient, GoogleAuth } from 'google-auth-library';
+import { Headers } from 'google-auth-library/build/src/auth/oauth2client';
+
+async function main() {
+  async function getAuthenticatedClient(): Promise<AuthClient> {  
+    const auth: GoogleAuth = new GoogleAuth({
+      scopes: 'https://www.googleapis.com/auth/cloud-platform',
+    });
+    const client: AuthClient = await auth.getClient();
+    return client;    
+  }
+
+  const authenticatedClient: AuthClient = await getAuthenticatedClient();
+  const headers: Headers = await authenticatedClient.getRequestHeaders();
+
+  const sdk = new NodeSDK({
+    traceExporter: new OTLPTraceExporter({
+      headers: headers,
+    }),
+  });
+  sdk.start();
+
+  app.get('/rolldice', (req: Request, res: Response) => {
+    const rolls = req.query.rolls ? parseInt(req.query.rolls.toString()) : NaN;
+    if (isNaN(rolls)) {
+      res
+          .status(400)
+          .send("Request parameter 'rolls' is missing or not a number.");
+      return;
+    }
+    res.send(JSON.stringify(rollTheDice(rolls, 1, 6)));
+  });
+
+  app.listen(PORT, () => {
+    console.log(`Listening for requests on http://localhost:${PORT}`);
+  });
+}
+
+main();

--- a/samples/otlptracegrpc/app.ts
+++ b/samples/otlptracegrpc/app.ts
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-import express, {Express, Request, Response} from 'express';
+
+import express, {Request, Response} from 'express';
 import {rollTheDice} from './dice';
 
 import {NodeSDK} from '@opentelemetry/sdk-node';
@@ -20,8 +20,8 @@ import {OTLPTraceExporter} from '@opentelemetry/exporter-trace-otlp-grpc';
 import {AuthClient, GoogleAuth} from 'google-auth-library';
 import {credentials} from '@grpc/grpc-js';
 
-const PORT: number = parseInt(process.env.PORT || '8080');
-const app: Express = express();
+const PORT = parseInt(process.env.PORT || '8080');
+const app = express();
 
 async function getAuthenticatedClient(): Promise<AuthClient> {
   const auth: GoogleAuth = new GoogleAuth({

--- a/samples/otlptracegrpc/client.ts
+++ b/samples/otlptracegrpc/client.ts
@@ -21,7 +21,7 @@ const APP_ENDPOINT = 'http://localhost:8080/rolldice';
 async function rollDice() {
   const numRolls = Math.floor(Math.random() * 10) + 1;
   console.log(`Making ${numRolls} rolls`);
-  const url = APP_ENDPOINT + '?rolls=' + numRolls;
+  const url = `${APP_ENDPOINT}?rolls=${numRolls}`;
   try {
     const response: AxiosResponse = await axios(url);
     if (response.status !== 200) {

--- a/samples/otlptracegrpc/client.ts
+++ b/samples/otlptracegrpc/client.ts
@@ -1,0 +1,24 @@
+/**
+ * Simple script that keeps generating spans by making random rolls via the running sample app.
+ */
+const INTERVAL_MS = 10000;
+const APP_ENDPOINT = 'http://localhost:8080/rolldice';
+
+async function rollDice() {
+    let numRolls = Math.floor(Math.random() * 10) + 1;
+    console.log(`Making ${numRolls} rolls`);
+    let url = APP_ENDPOINT + "?rolls=" + numRolls;
+    try {
+        const response = await fetch(url);
+        if (!response.ok) {
+            console.error("Error making roll", response.status);
+        } else {
+            console.log(response.statusText)
+        }
+    } catch(error) {
+        console.error()
+    }
+}
+
+const intervalId = setInterval(rollDice, 10 * 1000);
+console.log(`Rolling dice every ${INTERVAL_MS} ms with interval ID: ${intervalId}`);

--- a/samples/otlptracegrpc/client.ts
+++ b/samples/otlptracegrpc/client.ts
@@ -1,6 +1,18 @@
-/**
- * Simple script that keeps generating spans by making random rolls via the running sample app.
- */
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Simple script that keeps generating spans by making random rolls via the running sample app.
 const INTERVAL_MS = 10000;
 const APP_ENDPOINT = 'http://localhost:8080/rolldice';
 

--- a/samples/otlptracegrpc/client.ts
+++ b/samples/otlptracegrpc/client.ts
@@ -13,24 +13,28 @@
 // limitations under the License.
 
 // Simple script that keeps generating spans by making random rolls via the running sample app.
+import axios, {AxiosResponse} from 'axios';
+
 const INTERVAL_MS = 10000;
 const APP_ENDPOINT = 'http://localhost:8080/rolldice';
 
 async function rollDice() {
-    let numRolls = Math.floor(Math.random() * 10) + 1;
-    console.log(`Making ${numRolls} rolls`);
-    let url = APP_ENDPOINT + "?rolls=" + numRolls;
-    try {
-        const response = await fetch(url);
-        if (!response.ok) {
-            console.error("Error making roll", response.status);
-        } else {
-            console.log(response.statusText)
-        }
-    } catch(error) {
-        console.error()
+  const numRolls = Math.floor(Math.random() * 10) + 1;
+  console.log(`Making ${numRolls} rolls`);
+  const url = APP_ENDPOINT + '?rolls=' + numRolls;
+  try {
+    const response: AxiosResponse = await axios(url);
+    if (response.status !== 200) {
+      console.error('Error making roll', response.status);
+    } else {
+      console.log(response.statusText);
     }
+  } catch (error) {
+    console.error();
+  }
 }
 
 const intervalId = setInterval(rollDice, 10 * 1000);
-console.log(`Rolling dice every ${INTERVAL_MS} ms with interval ID: ${intervalId}`);
+console.log(
+  `Rolling dice every ${INTERVAL_MS} ms with interval ID: ${intervalId}`
+);

--- a/samples/otlptracegrpc/dice.ts
+++ b/samples/otlptracegrpc/dice.ts
@@ -1,0 +1,39 @@
+// Copyright OpenTelemetry Authors
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/*dice.ts*/
+import { trace } from '@opentelemetry/api';
+
+const tracer = trace.getTracer('dice-lib');
+
+function rollOnce(min: number, max: number): number  {
+  return Math.floor(Math.random() * (max - min) + min);
+}
+
+export function rollTheDice(rolls: number, min: number, max: number) {
+  // Create a span. A span must be closed.
+  return tracer.startActiveSpan('rollTheDice', (span) => {
+    const result:number[] = [];
+    for (let i = 0; i < rolls; i++) {
+      result.push(rollOnce(min, max));
+    }
+    // Be sure to end the span!
+    span.end();
+    return result;
+  });
+}
+
+module.exports = { rollTheDice };

--- a/samples/otlptracegrpc/dice.ts
+++ b/samples/otlptracegrpc/dice.ts
@@ -14,18 +14,18 @@
 // limitations under the License.
 //
 
-import { trace } from '@opentelemetry/api';
+import {trace} from '@opentelemetry/api';
 
 const tracer = trace.getTracer('dice-lib');
 
-function rollOnce(min: number, max: number): number  {
+function rollOnce(min: number, max: number): number {
   return Math.floor(Math.random() * (max - min) + min);
 }
 
 export function rollTheDice(rolls: number, min: number, max: number) {
   // Create a span. A span must be closed.
-  return tracer.startActiveSpan('rollTheDice', (span) => {
-    const result:number[] = [];
+  return tracer.startActiveSpan('rollTheDice', span => {
+    const result: number[] = [];
     for (let i = 0; i < rolls; i++) {
       result.push(rollOnce(min, max));
     }
@@ -35,4 +35,4 @@ export function rollTheDice(rolls: number, min: number, max: number) {
   });
 }
 
-module.exports = { rollTheDice };
+module.exports = {rollTheDice};

--- a/samples/otlptracegrpc/dice.ts
+++ b/samples/otlptracegrpc/dice.ts
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 
-/*dice.ts*/
 import { trace } from '@opentelemetry/api';
 
 const tracer = trace.getTracer('dice-lib');

--- a/samples/otlptracegrpc/package.json
+++ b/samples/otlptracegrpc/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "start": "ts-node ./app.ts",
+    "client": "ts-node ./client.ts",
     "lint": "gts lint",
     "clean": "gts clean",
     "fix": "gts fix",
@@ -19,7 +20,8 @@
     "@opentelemetry/sdk-node": "0.49.1",
     "@opentelemetry/semantic-conventions": "1.22.0",
     "express": "4.19.2",
-    "google-auth-library": "9.7.0"
+    "google-auth-library": "9.7.0",
+    "axios": "^1.6.8"
   },
   "devDependencies": {
     "gts": "^5.3.0"

--- a/samples/otlptracegrpc/package.json
+++ b/samples/otlptracegrpc/package.json
@@ -19,14 +19,16 @@
     "@opentelemetry/resources": "1.22.0",
     "@opentelemetry/sdk-node": "0.49.1",
     "@opentelemetry/semantic-conventions": "1.22.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "^0.51.0",
-    "@grpc/grpc-js": "^1.3.2",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.51.0",
+    "@grpc/grpc-js": "1.3.2",
     "express": "4.19.2",
     "google-auth-library": "9.7.0",
-    "axios": "^1.6.8"
+    "axios": "1.6.8"
   },
   "devDependencies": {
-    "gts": "^5.3.0"
+    "gts": "5.3.0",
+    "typescript": "4.9.5",
+    "ts-node": "10.9.2"
   },
   "description": "This example shows how to send traces to an OTLP *(OpenTelemetry Protocol)* endpoint that is protected by GCP authentication over gRPC."
 }

--- a/samples/otlptracegrpc/package.json
+++ b/samples/otlptracegrpc/package.json
@@ -2,15 +2,16 @@
   "name": "sample-app-grpc",
   "version": "0.1.0",
   "private": true,
-  "license": "Apache-2.0",
   "author": "Google Inc.",
-  "main": "index.ts",
+  "license": "Apache-2.0",
   "scripts": {
-    "start": "node ./app.ts"
+    "start": "ts-node ./app.ts",
+    "lint": "gts lint",
+    "clean": "gts clean",
+    "fix": "gts fix",
+    "compile": "tsc"
   },
   "keywords": [],
-  "author": "",
-  "license": "ISC",
   "dependencies": {
     "@opentelemetry/api": "1.8.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
@@ -19,5 +20,9 @@
     "@opentelemetry/semantic-conventions": "1.22.0",
     "express": "4.19.2",
     "google-auth-library": "9.7.0"
-  }
+  },
+  "devDependencies": {
+    "gts": "^5.3.0"
+  },
+  "description": "This example shows how to send traces to an OTLP *(OpenTelemetry Protocol)* endpoint that is protected by GCP authentication over gRPC."
 }

--- a/samples/otlptracegrpc/package.json
+++ b/samples/otlptracegrpc/package.json
@@ -19,6 +19,8 @@
     "@opentelemetry/resources": "1.22.0",
     "@opentelemetry/sdk-node": "0.49.1",
     "@opentelemetry/semantic-conventions": "1.22.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.51.0",
+    "@grpc/grpc-js": "^1.3.2",
     "express": "4.19.2",
     "google-auth-library": "9.7.0",
     "axios": "^1.6.8"

--- a/samples/otlptracegrpc/package.json
+++ b/samples/otlptracegrpc/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "sample-app-grpc",
+  "version": "0.1.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "author": "Google Inc.",
+  "main": "index.ts",
+  "scripts": {
+    "start": "node ./app.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@opentelemetry/api": "1.8.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-node": "0.49.1",
+    "@opentelemetry/semantic-conventions": "1.22.0",
+    "express": "4.19.2",
+    "google-auth-library": "9.7.0"
+  }
+}

--- a/samples/otlptracegrpc/tsconfig.json
+++ b/samples/otlptracegrpc/tsconfig.json
@@ -1,10 +1,11 @@
 {
-    "compilerOptions": {
-      "rootDir": ".",
-      "outDir": "build",
-      "esModuleInterop": true,
-    },
-    "include": [
-      "*.ts"    
-    ],
+  "extends": "../../node_modules/gts/tsconfig-google.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build",
+    "esModuleInterop": true
+  },
+  "include": [
+    "*.ts"
+  ]
 }

--- a/samples/otlptracegrpc/tsconfig.json
+++ b/samples/otlptracegrpc/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+      "rootDir": ".",
+      "outDir": "build",
+      "esModuleInterop": true,
+    },
+    "include": [
+      "*.ts"    
+    ],
+}


### PR DESCRIPTION
Adds sample for otlp trace export via grpc export. The credentials are added on a per call basis and auto-refresh.

#### Testing
 - Ran the sample app continuously for roughly 2 hours and generated spans at a constant rate.
 
 *Inspired by the existing [otlp-trace sample](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/pull/678). Adjusted copyrights accordingly.*
