### PR TITLE
chore(otlptraceexport): add empty test script so sample is compiled in CI

### DIFF
--- a/samples/otlptraceexport/package.json
+++ b/samples/otlptraceexport/package.json
@@ -12,7 +12,9 @@
     "lint": "gts lint",
     "clean": "gts clean",
     "fix": "gts fix",
-    "compile": "tsc"
+    "compile": "tsc",
+    "test": "",
+    "pretest": "npm run compile"
   },
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
This brings the sample in line with other typescript code in this repo that use `pretest` script to make sure everything compiles in CI. Since the sample has no tests, I've left the actual test script empty (test test runner fails if it finds no tests)

![image](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/assets/1510004/f56520c5-ab0b-4d35-8eaa-515516f2b67c)
