### PR TITLE
chore: update usage of @opentelemetry/semantic-conventions to avoid deprecated namespaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15309,7 +15309,6 @@
       "dependencies": {
         "@google-cloud/opentelemetry-resource-util": "^2.1.0",
         "@google-cloud/precise-date": "^4.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
         "google-auth-library": "^9.0.0",
         "googleapis": "^135.0.0"
       },
@@ -15760,6 +15759,7 @@
       "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "gcp-metadata": "^6.0.0"
       },
       "devDependencies": {
@@ -15784,8 +15784,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/resources": "^1.0.0"
       }
     },
     "packages/opentelemetry-resource-util/node_modules/typescript": {
@@ -15996,7 +15995,6 @@
         "@opentelemetry/exporter-trace-otlp-proto": "0.51.0",
         "@opentelemetry/resources": "1.24.0",
         "@opentelemetry/sdk-node": "0.51.0",
-        "@opentelemetry/semantic-conventions": "1.24.0",
         "axios": "1.6.8",
         "express": "4.19.2",
         "google-auth-library": "9.9.0"

--- a/packages/opentelemetry-cloud-monitoring-exporter/package.json
+++ b/packages/opentelemetry-cloud-monitoring-exporter/package.json
@@ -68,7 +68,6 @@
   "dependencies": {
     "@google-cloud/opentelemetry-resource-util": "^2.1.0",
     "@google-cloud/precise-date": "^4.0.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0",
     "google-auth-library": "^9.0.0",
     "googleapis": "^135.0.0"
   },

--- a/packages/opentelemetry-cloud-trace-exporter/README.md
+++ b/packages/opentelemetry-cloud-trace-exporter/README.md
@@ -42,15 +42,22 @@ By default, OpenTelemetry resource attributes which do not map to a monitored re
 
 For example, if you are setting up a resource with the "service" semantic attributes:
 ```typescript
-const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
+const {
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_SERVICE_NAMESPACE,
+  SEMRESATTRS_SERVICE_VERSION,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+} = require('@opentelemetry/semantic-conventions');
 
 const provider = new NodeTracerProvider({
   // ...
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: 'things-service',
-    [SemanticResourceAttributes.SERVICE_NAMESPACE]: 'things',
-    [SemanticResourceAttributes.SERVICE_VERSION]: '1.0.0',
-    [SemanticResourceAttributes.SERVICE_INSTANCE_ID]: 'abc123',
+
+  SEMRESATTRS_SERVICE_NAME,
+    [SEMRESATTRS_SERVICE_NAME]: 'things-service',
+    [SEMRESATTRS_SERVICE_NAMESPACE]: 'things',
+    [SEMRESATTRS_SERVICE_VERSION]: '1.0.0',
+    [SEMRESATTRS_SERVICE_INSTANCE_ID]: 'abc123',
   }),
 })
 ```

--- a/packages/opentelemetry-resource-util/package.json
+++ b/packages/opentelemetry-resource-util/package.json
@@ -63,10 +63,10 @@
     "typescript": "4.9.5"
   },
   "peerDependencies": {
-    "@opentelemetry/resources": "^1.0.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0"
+    "@opentelemetry/resources": "^1.0.0"
   },
   "dependencies": {
-    "gcp-metadata": "^6.0.0"
+    "gcp-metadata": "^6.0.0",
+    "@opentelemetry/semantic-conventions": "^1.22.0"
   }
 }

--- a/packages/opentelemetry-resource-util/src/detector/detector.ts
+++ b/packages/opentelemetry-resource-util/src/detector/detector.ts
@@ -13,18 +13,33 @@
 // limitations under the License.
 
 import {
-  SemanticResourceAttributes as Semconv,
-  CloudPlatformValues,
-  CloudProviderValues,
+  CLOUDPLATFORMVALUES_GCP_APP_ENGINE,
+  CLOUDPLATFORMVALUES_GCP_CLOUD_FUNCTIONS,
+  CLOUDPLATFORMVALUES_GCP_CLOUD_RUN,
+  CLOUDPLATFORMVALUES_GCP_COMPUTE_ENGINE,
+  CLOUDPLATFORMVALUES_GCP_KUBERNETES_ENGINE,
+  CLOUDPROVIDERVALUES_GCP,
+  SEMRESATTRS_CLOUD_ACCOUNT_ID,
+  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_FAAS_INSTANCE,
+  SEMRESATTRS_FAAS_NAME,
+  SEMRESATTRS_FAAS_VERSION,
+  SEMRESATTRS_HOST_ID,
+  SEMRESATTRS_HOST_NAME,
+  SEMRESATTRS_HOST_TYPE,
+  SEMRESATTRS_K8S_CLUSTER_NAME,
 } from '@opentelemetry/semantic-conventions';
 
+import {Attributes} from '@opentelemetry/api';
 import {Detector, DetectorSync, Resource} from '@opentelemetry/resources';
-import * as gce from './gce';
-import * as gke from './gke';
+import * as metadata from 'gcp-metadata';
 import * as faas from './faas';
 import * as gae from './gae';
-import * as metadata from 'gcp-metadata';
-import {Attributes} from '@opentelemetry/api';
+import * as gce from './gce';
+import * as gke from './gke';
 
 async function detect(): Promise<Resource> {
   if (!(await metadata.isAvailable())) {
@@ -56,12 +71,12 @@ async function gkeResource(): Promise<Resource> {
   ]);
 
   return await makeResource({
-    [Semconv.CLOUD_PLATFORM]: CloudPlatformValues.GCP_KUBERNETES_ENGINE,
+    [SEMRESATTRS_CLOUD_PLATFORM]: CLOUDPLATFORMVALUES_GCP_KUBERNETES_ENGINE,
     [zoneOrRegion.type === 'zone'
-      ? Semconv.CLOUD_AVAILABILITY_ZONE
-      : Semconv.CLOUD_REGION]: zoneOrRegion.value,
-    [Semconv.K8S_CLUSTER_NAME]: k8sClusterName,
-    [Semconv.HOST_ID]: hostId,
+      ? SEMRESATTRS_CLOUD_AVAILABILITY_ZONE
+      : SEMRESATTRS_CLOUD_REGION]: zoneOrRegion.value,
+    [SEMRESATTRS_K8S_CLUSTER_NAME]: k8sClusterName,
+    [SEMRESATTRS_HOST_ID]: hostId,
   });
 }
 
@@ -75,11 +90,11 @@ async function cloudRunResource(): Promise<Resource> {
     ]);
 
   return await makeResource({
-    [Semconv.CLOUD_PLATFORM]: CloudPlatformValues.GCP_CLOUD_RUN,
-    [Semconv.FAAS_NAME]: faasName,
-    [Semconv.FAAS_VERSION]: faasVersion,
-    [Semconv.FAAS_INSTANCE]: faasInstance,
-    [Semconv.CLOUD_REGION]: faasCloudRegion,
+    [SEMRESATTRS_CLOUD_PLATFORM]: CLOUDPLATFORMVALUES_GCP_CLOUD_RUN,
+    [SEMRESATTRS_FAAS_NAME]: faasName,
+    [SEMRESATTRS_FAAS_VERSION]: faasVersion,
+    [SEMRESATTRS_FAAS_INSTANCE]: faasInstance,
+    [SEMRESATTRS_CLOUD_REGION]: faasCloudRegion,
   });
 }
 
@@ -93,11 +108,11 @@ async function cloudFunctionsResource(): Promise<Resource> {
     ]);
 
   return await makeResource({
-    [Semconv.CLOUD_PLATFORM]: CloudPlatformValues.GCP_CLOUD_FUNCTIONS,
-    [Semconv.FAAS_NAME]: faasName,
-    [Semconv.FAAS_VERSION]: faasVersion,
-    [Semconv.FAAS_INSTANCE]: faasInstance,
-    [Semconv.CLOUD_REGION]: faasCloudRegion,
+    [SEMRESATTRS_CLOUD_PLATFORM]: CLOUDPLATFORMVALUES_GCP_CLOUD_FUNCTIONS,
+    [SEMRESATTRS_FAAS_NAME]: faasName,
+    [SEMRESATTRS_FAAS_VERSION]: faasVersion,
+    [SEMRESATTRS_FAAS_INSTANCE]: faasInstance,
+    [SEMRESATTRS_CLOUD_REGION]: faasCloudRegion,
   });
 }
 
@@ -118,12 +133,12 @@ async function gaeResource(): Promise<Resource> {
   ]);
 
   return await makeResource({
-    [Semconv.CLOUD_PLATFORM]: CloudPlatformValues.GCP_APP_ENGINE,
-    [Semconv.FAAS_NAME]: faasName,
-    [Semconv.FAAS_VERSION]: faasVersion,
-    [Semconv.FAAS_INSTANCE]: faasInstance,
-    [Semconv.CLOUD_AVAILABILITY_ZONE]: zone,
-    [Semconv.CLOUD_REGION]: region,
+    [SEMRESATTRS_CLOUD_PLATFORM]: CLOUDPLATFORMVALUES_GCP_APP_ENGINE,
+    [SEMRESATTRS_FAAS_NAME]: faasName,
+    [SEMRESATTRS_FAAS_VERSION]: faasVersion,
+    [SEMRESATTRS_FAAS_INSTANCE]: faasInstance,
+    [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE]: zone,
+    [SEMRESATTRS_CLOUD_REGION]: region,
   });
 }
 
@@ -136,12 +151,12 @@ async function gceResource(): Promise<Resource> {
   ]);
 
   return await makeResource({
-    [Semconv.CLOUD_PLATFORM]: CloudPlatformValues.GCP_COMPUTE_ENGINE,
-    [Semconv.CLOUD_AVAILABILITY_ZONE]: zoneAndRegion.zone,
-    [Semconv.CLOUD_REGION]: zoneAndRegion.region,
-    [Semconv.HOST_TYPE]: hostType,
-    [Semconv.HOST_ID]: hostId,
-    [Semconv.HOST_NAME]: hostName,
+    [SEMRESATTRS_CLOUD_PLATFORM]: CLOUDPLATFORMVALUES_GCP_COMPUTE_ENGINE,
+    [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE]: zoneAndRegion.zone,
+    [SEMRESATTRS_CLOUD_REGION]: zoneAndRegion.region,
+    [SEMRESATTRS_HOST_TYPE]: hostType,
+    [SEMRESATTRS_HOST_ID]: hostId,
+    [SEMRESATTRS_HOST_NAME]: hostName,
   });
 }
 
@@ -149,8 +164,8 @@ async function makeResource(attrs: Attributes): Promise<Resource> {
   const project = await metadata.project<string>('project-id');
 
   return new Resource({
-    [Semconv.CLOUD_PROVIDER]: CloudProviderValues.GCP,
-    [Semconv.CLOUD_ACCOUNT_ID]: project,
+    [SEMRESATTRS_CLOUD_PROVIDER]: CLOUDPROVIDERVALUES_GCP,
+    [SEMRESATTRS_CLOUD_ACCOUNT_ID]: project,
     ...attrs,
   });
 }

--- a/packages/opentelemetry-resource-util/src/index.ts
+++ b/packages/opentelemetry-resource-util/src/index.ts
@@ -15,8 +15,29 @@
 import {Attributes, AttributeValue} from '@opentelemetry/api';
 import {IResource} from '@opentelemetry/resources';
 import {
-  SemanticResourceAttributes,
-  CloudPlatformValues,
+  CLOUDPLATFORMVALUES_AWS_EC2,
+  CLOUDPLATFORMVALUES_GCP_APP_ENGINE,
+  CLOUDPLATFORMVALUES_GCP_CLOUD_FUNCTIONS,
+  CLOUDPLATFORMVALUES_GCP_CLOUD_RUN,
+  CLOUDPLATFORMVALUES_GCP_COMPUTE_ENGINE,
+  CLOUDPLATFORMVALUES_GCP_KUBERNETES_ENGINE,
+  SEMRESATTRS_CLOUD_ACCOUNT_ID,
+  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_FAAS_INSTANCE,
+  SEMRESATTRS_FAAS_NAME,
+  SEMRESATTRS_FAAS_VERSION,
+  SEMRESATTRS_HOST_ID,
+  SEMRESATTRS_HOST_NAME,
+  SEMRESATTRS_K8S_CLUSTER_NAME,
+  SEMRESATTRS_K8S_CONTAINER_NAME,
+  SEMRESATTRS_K8S_NAMESPACE_NAME,
+  SEMRESATTRS_K8S_NODE_NAME,
+  SEMRESATTRS_K8S_POD_NAME,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_SERVICE_NAMESPACE,
 } from '@opentelemetry/semantic-conventions';
 
 const AWS_ACCOUNT = 'aws_account';
@@ -60,124 +81,129 @@ const UNKNOWN_SERVICE_PREFIX = 'unknown_service';
  */
 const MAPPINGS = {
   [GCE_INSTANCE]: {
-    [ZONE]: {otelKeys: [SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE]},
-    [INSTANCE_ID]: {otelKeys: [SemanticResourceAttributes.HOST_ID]},
+    [ZONE]: {
+      otelKeys: [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE],
+    },
+    [INSTANCE_ID]: {otelKeys: [SEMRESATTRS_HOST_ID]},
   },
   [K8S_CONTAINER]: {
     [LOCATION]: {
-      otelKeys: [
-        SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE,
-        SemanticResourceAttributes.CLOUD_REGION,
-      ],
+      otelKeys: [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE, SEMRESATTRS_CLOUD_REGION],
     },
-    [CLUSTER_NAME]: {otelKeys: [SemanticResourceAttributes.K8S_CLUSTER_NAME]},
+    [CLUSTER_NAME]: {
+      otelKeys: [SEMRESATTRS_K8S_CLUSTER_NAME],
+    },
     [NAMESPACE_NAME]: {
-      otelKeys: [SemanticResourceAttributes.K8S_NAMESPACE_NAME],
+      otelKeys: [SEMRESATTRS_K8S_NAMESPACE_NAME],
     },
-    [POD_NAME]: {otelKeys: [SemanticResourceAttributes.K8S_POD_NAME]},
+    [POD_NAME]: {
+      otelKeys: [SEMRESATTRS_K8S_POD_NAME],
+    },
     [CONTAINER_NAME]: {
-      otelKeys: [SemanticResourceAttributes.K8S_CONTAINER_NAME],
+      otelKeys: [SEMRESATTRS_K8S_CONTAINER_NAME],
     },
   },
   [K8S_POD]: {
     [LOCATION]: {
-      otelKeys: [
-        SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE,
-        SemanticResourceAttributes.CLOUD_REGION,
-      ],
+      otelKeys: [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE, SEMRESATTRS_CLOUD_REGION],
     },
-    [CLUSTER_NAME]: {otelKeys: [SemanticResourceAttributes.K8S_CLUSTER_NAME]},
+    [CLUSTER_NAME]: {
+      otelKeys: [SEMRESATTRS_K8S_CLUSTER_NAME],
+    },
     [NAMESPACE_NAME]: {
-      otelKeys: [SemanticResourceAttributes.K8S_NAMESPACE_NAME],
+      otelKeys: [SEMRESATTRS_K8S_NAMESPACE_NAME],
     },
-    [POD_NAME]: {otelKeys: [SemanticResourceAttributes.K8S_POD_NAME]},
+    [POD_NAME]: {
+      otelKeys: [SEMRESATTRS_K8S_POD_NAME],
+    },
   },
   [K8S_NODE]: {
     [LOCATION]: {
-      otelKeys: [
-        SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE,
-        SemanticResourceAttributes.CLOUD_REGION,
-      ],
+      otelKeys: [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE, SEMRESATTRS_CLOUD_REGION],
     },
-    [CLUSTER_NAME]: {otelKeys: [SemanticResourceAttributes.K8S_CLUSTER_NAME]},
-    [NODE_NAME]: {otelKeys: [SemanticResourceAttributes.K8S_NODE_NAME]},
+    [CLUSTER_NAME]: {
+      otelKeys: [SEMRESATTRS_K8S_CLUSTER_NAME],
+    },
+    [NODE_NAME]: {
+      otelKeys: [SEMRESATTRS_K8S_NODE_NAME],
+    },
   },
   [K8S_CLUSTER]: {
     [LOCATION]: {
-      otelKeys: [
-        SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE,
-        SemanticResourceAttributes.CLOUD_REGION,
-      ],
+      otelKeys: [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE, SEMRESATTRS_CLOUD_REGION],
     },
-    [CLUSTER_NAME]: {otelKeys: [SemanticResourceAttributes.K8S_CLUSTER_NAME]},
+    [CLUSTER_NAME]: {
+      otelKeys: [SEMRESATTRS_K8S_CLUSTER_NAME],
+    },
   },
   [AWS_EC2_INSTANCE]: {
-    [INSTANCE_ID]: {otelKeys: [SemanticResourceAttributes.HOST_ID]},
+    [INSTANCE_ID]: {otelKeys: [SEMRESATTRS_HOST_ID]},
     [REGION]: {
-      otelKeys: [
-        SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE,
-        SemanticResourceAttributes.CLOUD_REGION,
-      ],
+      otelKeys: [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE, SEMRESATTRS_CLOUD_REGION],
     },
-    [AWS_ACCOUNT]: {otelKeys: [SemanticResourceAttributes.CLOUD_ACCOUNT_ID]},
+    [AWS_ACCOUNT]: {
+      otelKeys: [SEMRESATTRS_CLOUD_ACCOUNT_ID],
+    },
   },
   [CLOUD_RUN_REVISION]: {
-    [LOCATION]: {otelKeys: [SemanticResourceAttributes.CLOUD_REGION]},
-    [SERVICE_NAME]: {otelKeys: [SemanticResourceAttributes.FAAS_NAME]},
-    [CONFIGURATION_NAME]: {otelKeys: [SemanticResourceAttributes.FAAS_NAME]},
-    [REVISION_NAME]: {otelKeys: [SemanticResourceAttributes.FAAS_VERSION]},
+    [LOCATION]: {
+      otelKeys: [SEMRESATTRS_CLOUD_REGION],
+    },
+    [SERVICE_NAME]: {
+      otelKeys: [SEMRESATTRS_FAAS_NAME],
+    },
+    [CONFIGURATION_NAME]: {
+      otelKeys: [SEMRESATTRS_FAAS_NAME],
+    },
+    [REVISION_NAME]: {
+      otelKeys: [SEMRESATTRS_FAAS_VERSION],
+    },
   },
   [CLOUD_FUNCTION]: {
-    [REGION]: {otelKeys: [SemanticResourceAttributes.CLOUD_REGION]},
-    [FUNCTION_NAME]: {otelKeys: [SemanticResourceAttributes.FAAS_NAME]},
+    [REGION]: {otelKeys: [SEMRESATTRS_CLOUD_REGION]},
+    [FUNCTION_NAME]: {
+      otelKeys: [SEMRESATTRS_FAAS_NAME],
+    },
   },
   [GAE_INSTANCE]: {
     [LOCATION]: {
-      otelKeys: [
-        SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE,
-        SemanticResourceAttributes.CLOUD_REGION,
-      ],
+      otelKeys: [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE, SEMRESATTRS_CLOUD_REGION],
     },
-    [GAE_MODULE_ID]: {otelKeys: [SemanticResourceAttributes.FAAS_NAME]},
-    [GAE_VERSION_ID]: {otelKeys: [SemanticResourceAttributes.FAAS_VERSION]},
-    [INSTANCE_ID]: {otelKeys: [SemanticResourceAttributes.FAAS_INSTANCE]},
+    [GAE_MODULE_ID]: {
+      otelKeys: [SEMRESATTRS_FAAS_NAME],
+    },
+    [GAE_VERSION_ID]: {
+      otelKeys: [SEMRESATTRS_FAAS_VERSION],
+    },
+    [INSTANCE_ID]: {
+      otelKeys: [SEMRESATTRS_FAAS_INSTANCE],
+    },
   },
   [GENERIC_TASK]: {
     [LOCATION]: {
-      otelKeys: [
-        SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE,
-        SemanticResourceAttributes.CLOUD_REGION,
-      ],
+      otelKeys: [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE, SEMRESATTRS_CLOUD_REGION],
       fallback: 'global',
     },
-    [NAMESPACE]: {otelKeys: [SemanticResourceAttributes.SERVICE_NAMESPACE]},
+    [NAMESPACE]: {
+      otelKeys: [SEMRESATTRS_SERVICE_NAMESPACE],
+    },
     [JOB]: {
-      otelKeys: [
-        SemanticResourceAttributes.SERVICE_NAME,
-        SemanticResourceAttributes.FAAS_NAME,
-      ],
+      otelKeys: [SEMRESATTRS_SERVICE_NAME, SEMRESATTRS_FAAS_NAME],
     },
     [TASK_ID]: {
-      otelKeys: [
-        SemanticResourceAttributes.SERVICE_INSTANCE_ID,
-        SemanticResourceAttributes.FAAS_INSTANCE,
-      ],
+      otelKeys: [SEMRESATTRS_SERVICE_INSTANCE_ID, SEMRESATTRS_FAAS_INSTANCE],
     },
   },
   [GENERIC_NODE]: {
     [LOCATION]: {
-      otelKeys: [
-        SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE,
-        SemanticResourceAttributes.CLOUD_REGION,
-      ],
+      otelKeys: [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE, SEMRESATTRS_CLOUD_REGION],
       fallback: 'global',
     },
-    [NAMESPACE]: {otelKeys: [SemanticResourceAttributes.SERVICE_NAMESPACE]},
+    [NAMESPACE]: {
+      otelKeys: [SEMRESATTRS_SERVICE_NAMESPACE],
+    },
     [NODE_ID]: {
-      otelKeys: [
-        SemanticResourceAttributes.HOST_ID,
-        SemanticResourceAttributes.HOST_NAME,
-      ],
+      otelKeys: [SEMRESATTRS_HOST_ID, SEMRESATTRS_HOST_NAME],
     },
   },
 } as const;
@@ -222,44 +248,43 @@ export function mapOtelResourceToMonitoredResource(
   includeUnsupportedResources = false
 ): MonitoredResource {
   const attrs = resource.attributes;
-  const platform = attrs[SemanticResourceAttributes.CLOUD_PLATFORM];
+  const platform = attrs[SEMRESATTRS_CLOUD_PLATFORM];
 
   let mr: MonitoredResource;
-  if (platform === CloudPlatformValues.GCP_COMPUTE_ENGINE) {
+  if (platform === CLOUDPLATFORMVALUES_GCP_COMPUTE_ENGINE) {
     mr = createMonitoredResource(GCE_INSTANCE, attrs);
-  } else if (platform === CloudPlatformValues.GCP_KUBERNETES_ENGINE) {
-    if (SemanticResourceAttributes.K8S_CONTAINER_NAME in attrs) {
+  } else if (platform === CLOUDPLATFORMVALUES_GCP_KUBERNETES_ENGINE) {
+    if (SEMRESATTRS_K8S_CONTAINER_NAME in attrs) {
       mr = createMonitoredResource(K8S_CONTAINER, attrs);
-    } else if (SemanticResourceAttributes.K8S_POD_NAME in attrs) {
+    } else if (SEMRESATTRS_K8S_POD_NAME in attrs) {
       mr = createMonitoredResource(K8S_POD, attrs);
-    } else if (SemanticResourceAttributes.K8S_NODE_NAME in attrs) {
+    } else if (SEMRESATTRS_K8S_NODE_NAME in attrs) {
       mr = createMonitoredResource(K8S_NODE, attrs);
     } else {
       mr = createMonitoredResource(K8S_CLUSTER, attrs);
     }
-  } else if (platform === CloudPlatformValues.GCP_APP_ENGINE) {
+  } else if (platform === CLOUDPLATFORMVALUES_GCP_APP_ENGINE) {
     mr = createMonitoredResource(GAE_INSTANCE, attrs);
-  } else if (platform === CloudPlatformValues.AWS_EC2) {
+  } else if (platform === CLOUDPLATFORMVALUES_AWS_EC2) {
     mr = createMonitoredResource(AWS_EC2_INSTANCE, attrs);
   }
   // Cloud Run and Cloud Functions are not writeable for custom metrics yet
   else if (
     includeUnsupportedResources &&
-    platform === CloudPlatformValues.GCP_CLOUD_RUN
+    platform === CLOUDPLATFORMVALUES_GCP_CLOUD_RUN
   ) {
     mr = createMonitoredResource(CLOUD_RUN_REVISION, attrs);
   } else if (
     includeUnsupportedResources &&
-    platform === CloudPlatformValues.GCP_CLOUD_FUNCTIONS
+    platform === CLOUDPLATFORMVALUES_GCP_CLOUD_FUNCTIONS
   ) {
     mr = createMonitoredResource(CLOUD_FUNCTION, attrs);
   } else {
     // fallback to generic_task
     if (
-      (SemanticResourceAttributes.SERVICE_NAME in attrs ||
-        SemanticResourceAttributes.FAAS_NAME in attrs) &&
-      (SemanticResourceAttributes.SERVICE_INSTANCE_ID in attrs ||
-        SemanticResourceAttributes.FAAS_INSTANCE in attrs)
+      (SEMRESATTRS_SERVICE_NAME in attrs || SEMRESATTRS_FAAS_NAME in attrs) &&
+      (SEMRESATTRS_SERVICE_INSTANCE_ID in attrs ||
+        SEMRESATTRS_FAAS_INSTANCE in attrs)
     ) {
       mr = createMonitoredResource(GENERIC_TASK, attrs);
     } else {
@@ -293,11 +318,11 @@ function createMonitoredResource(
 
     if (
       mrValue === undefined &&
-      mapConfig.otelKeys.includes(SemanticResourceAttributes.SERVICE_NAME)
+      mapConfig.otelKeys.includes(SEMRESATTRS_SERVICE_NAME)
     ) {
       // The service name started with unknown_service, was ignored above, and we couldn't find
       // a better value for mrValue.
-      mrValue = resourceAttrs[SemanticResourceAttributes.SERVICE_NAME];
+      mrValue = resourceAttrs[SEMRESATTRS_SERVICE_NAME];
     }
     if (mrValue === undefined) {
       mrValue = mapConfig.fallback ?? '';

--- a/samples/otlptraceexport/package.json
+++ b/samples/otlptraceexport/package.json
@@ -21,7 +21,6 @@
     "@opentelemetry/api": "1.8.0",
     "@opentelemetry/resources": "1.24.0",
     "@opentelemetry/sdk-node": "0.51.0",
-    "@opentelemetry/semantic-conventions": "1.24.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.51.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.51.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.51.0",


### PR DESCRIPTION
[Since v1.22.0](https://github.com/open-telemetry/opentelemetry-js/blob/main/CHANGELOG.md#rocket-enhancement-3), the semantic conventions package exports individual strings and deprecated the object namespace approach. Note, this is not a breaking change or affect our support in any way.
