### PR TITLE
fix(resource-detector): properly detect zone on AppEngine standard

### DIFF
--- a/packages/opentelemetry-resource-util/src/detector/detector.ts
+++ b/packages/opentelemetry-resource-util/src/detector/detector.ts
@@ -123,10 +123,8 @@ async function gaeResource(): Promise<Resource> {
       gae.standardAvailabilityZone(),
       gae.standardCloudRegion(),
     ]);
-    console.log('Got GAE standard zone=%s and region=%s', zone, region);
   } else {
     ({zone, region} = await gce.availabilityZoneAndRegion());
-    console.log('Got GAE flex zone=%s and region=%s', zone, region);
   }
   const [faasName, faasVersion, faasInstance] = await Promise.all([
     gae.serviceName(),

--- a/packages/opentelemetry-resource-util/src/detector/detector.ts
+++ b/packages/opentelemetry-resource-util/src/detector/detector.ts
@@ -123,8 +123,10 @@ async function gaeResource(): Promise<Resource> {
       gae.standardAvailabilityZone(),
       gae.standardCloudRegion(),
     ]);
+    console.log('Got GAE standard zone=%s and region=%s', zone, region);
   } else {
     ({zone, region} = await gce.availabilityZoneAndRegion());
+    console.log('Got GAE flex zone=%s and region=%s', zone, region);
   }
   const [faasName, faasVersion, faasInstance] = await Promise.all([
     gae.serviceName(),

--- a/packages/opentelemetry-resource-util/src/detector/gae.ts
+++ b/packages/opentelemetry-resource-util/src/detector/gae.ts
@@ -76,7 +76,9 @@ export async function flexAvailabilityZoneAndRegion(): Promise<{
  * true before calling this, or it may throw exceptions.
  */
 export async function standardAvailabilityZone(): Promise<string> {
-  return await metadata.instance<string>(ZONE_METADATA_ATTR);
+  const zone = await metadata.instance<string>(ZONE_METADATA_ATTR);
+  // zone is of the form "projects/233510669999/zones/us15"
+  return zone.slice(zone.lastIndexOf('/') + 1);
 }
 
 /**

--- a/packages/opentelemetry-resource-util/test/detector/gae.test.ts
+++ b/packages/opentelemetry-resource-util/test/detector/gae.test.ts
@@ -88,9 +88,12 @@ describe('App Engine (GAE)', () => {
 
   describe('GAE standard zone and region', () => {
     it('detects zone', async () => {
-      metadataStub.instance.withArgs('zone').resolves('us-east4-b');
+      metadataStub.instance
+        .withArgs('zone')
+        .resolves('projects/233510669999/zones/us15');
+
       const zone = await gae.standardAvailabilityZone();
-      assert.strict(zone, 'us-east4-b');
+      assert.strictEqual(zone, 'us15');
     });
 
     it('detects region', async () => {


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/655

It turns out GAE standard environment's metadata server returns a zone string like `projects/myproject/zones/us15`. ut integration tests only run on AppEngine flex not standard so this wasn't caught 🙁. Here are HTTP logs I printed out from a sample app:

```json
{
  "jsonPayload": {
    "message": "gaxios metadata request",
    "responseData": "projects/<project>/zones/us15",
    "requestUrl": "http://169.254.169.254/computeMetadata/v1/instance/zone"
  },
  "resource": {
    "type": "gae_app",
    "labels": {
      "zone": "us15",
      "version_id": "20240503t222051",
      "project_id": "otel-starter-project",
      "module_id": "default"
    }
  }
}
```

I updated the tests and manually tested a sample app on GAE standard writing metrics: 
![image](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/assets/1510004/41f12b54-c3b0-4163-88e4-de15c23628b6)

---
I think this bug is also affecting all other resource detectors e.g. [Go's impl that this was copied from](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/bda7f022e62f4ec2c0c112a0f4485b8c89746bcd/detectors/gcp/app_engine.go#L68-L71)
