### PR TITLE
chore: fix tsconfigs to all be the same

### DIFF
--- a/samples/instrumentation-quickstart/tsconfig.json
+++ b/samples/instrumentation-quickstart/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./node_modules/gts/tsconfig-google.json",
+  "extends": "gts/tsconfig-google.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build"

--- a/samples/otlptraceexport/tsconfig.json
+++ b/samples/otlptraceexport/tsconfig.json
@@ -1,8 +1,12 @@
 {
-  "extends": "../../node_modules/gts/tsconfig-google.json",
+  "extends": "gts/tsconfig-google.json",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build",
     "esModuleInterop": true
-  }
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
 }


### PR DESCRIPTION
By fixing the `extends` to be the same. Previous versions of typescript required a path but now an NPM import path works. For the e2e-test package, i had to leave as is because ncc breaks and I don't have time to look into it.
