### PR TITLE
fix(trace-exporter): include protos.json in the npm pack tarball

### DIFF
--- a/packages/opentelemetry-cloud-trace-exporter/package.json
+++ b/packages/opentelemetry-cloud-trace-exporter/package.json
@@ -30,6 +30,7 @@
   "files": [
     "build/src/**/*.js",
     "build/src/**/*.d.ts",
+    "build/protos/**/*.json",
     "doc",
     "LICENSE",
     "README.md"


### PR DESCRIPTION
This fixes the issue of https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/768 but I will leave it open until I make a new patch release

NPM pack now includes the `protos.json` in the tarball:
```sh
$ npm pack
npm notice
npm notice 📦  @google-cloud/opentelemetry-cloud-trace-exporter@2.4.0
npm notice === Tarball Contents ===
npm notice 11.4kB  LICENSE
npm notice 4.3kB   README.md
npm notice 117.9kB build/protos/protos.json
npm notice 1.5kB   build/src/external-types.d.ts
npm notice 707B    build/src/external-types.js
npm notice 59B     build/src/index.d.ts
npm notice 1.5kB   build/src/index.js
npm notice 1.2kB   build/src/trace.d.ts
npm notice 6.0kB   build/src/trace.js
npm notice 268B    build/src/transform.d.ts
npm notice 8.6kB   build/src/transform.js
npm notice 3.1kB   build/src/types.d.ts
npm notice 3.1kB   build/src/types.js
npm notice 40B     build/src/version.d.ts
npm notice 842B    build/src/version.js
npm notice 2.1kB   package.json
npm notice === Tarball Details ===
npm notice name:          @google-cloud/opentelemetry-cloud-trace-exporter
npm notice version:       2.4.0
npm notice filename:      google-cloud-opentelemetry-cloud-trace-exporter-2.4.0.tgz
npm notice package size:  20.7 kB
npm notice unpacked size: 162.4 kB
npm notice shasum:        e2015c681dc29168ae44b86a8a75f9507fa7a75f
npm notice integrity:     sha512-8AvliiVQ80xIc[...]TbipPBJsLM4cA==
npm notice total files:   16
npm notice
google-cloud-opentelemetry-cloud-trace-exporter-2.4.0.tgz
```

## Testing it
I also verified by installing this tarball and requiring the package now works:
```console
$ npm init -y
Wrote to /path/package.json:

{
  "name": "testnpm",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "keywords": [],
  "author": "",
  "license": "ISC"
}


aaronabbott@aaronabbott2:~/tmp/testnpm$ npm install ~/repo/opentelemetry-operations-js/packages/opentelemetry-cloud-trace-exporter/google-cloud-opentelemetry-cloud-trace-exporter-2.4.0.tgz

added 64 packages, and audited 65 packages in 2s

7 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
aaronabbott@aaronabbott2:~/tmp/testnpm$ node
Welcome to Node.js v22.6.0.
Type ".help" for more information.
> let {TraceExporter} = require('@google-cloud/opentelemetry-cloud-trace-exporter');
undefined
> new TraceExporter;
TraceExporter {
  ...
}
```