### PR TITLE
feat: use exponential histograms for the quickstart sample

### DIFF
--- a/samples/instrumentation-quickstart/docker-compose.yaml
+++ b/samples/instrumentation-quickstart/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
     depends_on:
       - otelcol
   otelcol:
-    image: otel/opentelemetry-collector-contrib:0.110.0
+    image: otel/opentelemetry-collector-contrib:0.115.1
     volumes:
       - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
       - logs:/var/log:ro

--- a/samples/instrumentation-quickstart/otel-collector-config.yaml
+++ b/samples/instrumentation-quickstart/otel-collector-config.yaml
@@ -109,6 +109,14 @@ processors:
     detectors: ["env", "gcp"]
 
 service:
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '0.0.0.0'
+                port: 8888
   pipelines:
     traces:
       receivers: ["otlp"]

--- a/samples/instrumentation-quickstart/src/instrumentation.ts
+++ b/samples/instrumentation-quickstart/src/instrumentation.ts
@@ -55,8 +55,8 @@ function getMetricReader() {
           // Use exponential histograms for histogram instruments.
           // This can be done using an environment variable after
           // https://github.com/open-telemetry/opentelemetry-js/issues/3920 is implemented.
-          aggregationPreference: (_instrumentType: InstrumentType) =>  {
-            if (_instrumentType === InstrumentType.HISTOGRAM) {
+          aggregationPreference: (instrumentType: InstrumentType) =>  {
+            if (instrumentType === InstrumentType.HISTOGRAM) {
               return new ExponentialHistogramAggregation()
             }
             return new DefaultAggregation()


### PR DESCRIPTION
Same as https://github.com/GoogleCloudPlatform/opentelemetry-operations-python/pull/364.

This also updates the collector version.

Since the environment variable isn't supported yet, I had to add this as an option to the OTLP exporter.