### PR TITLE
chore!: drop support for EOL Node.js versions <18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,19 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 16, 18, 19]
-        include:
-          - node: 14
-            npm-version: ^7
+        node: [18, 20, 22, 24]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-      # TODO: remove once node 14 is dropped
-      - name: Install npm@${{ matrix.npm-version }}
-        if: matrix.npm-version
-        run: npm install -g npm@${{ matrix.npm-version }}
       - run: |
           node --version
           npm --version
@@ -38,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 19
+          node-version: 24
       - run: npm install
       - run: npm run lint
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Operations Exporters for JavaScript
 
-The packages in this repository support all [officially supported Node.js versions](https://nodejs.org/en/about/releases/) (10, 12, 14, 16).
+The packages in this repository support all [officially supported Node.js versions](https://nodejs.org/en/about/releases/) (18, 20, 22, 24).
 
 To get started with instrumentation in Google Cloud, see [Generate traces and metrics with
 Node.js](https://cloud.google.com/stackdriver/docs/instrumentation/setup/nodejs).

--- a/cloudbuild-e2e-cloud-functions-gen2.yaml
+++ b/cloudbuild-e2e-cloud-functions-gen2.yaml
@@ -46,7 +46,7 @@ steps:
     args:
       - cloud-functions-gen2
       - --functionsource=/workspace/e2e-test-server/dist/function-source.zip
-      - --runtime=nodejs16
+      - --runtime=nodejs20
       - --entrypoint=cloudFunctionHandler
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs

--- a/e2e-test-server/package.json
+++ b/e2e-test-server/package.json
@@ -13,7 +13,7 @@
   "license": "Apache-2.0",
   "keywords": [],
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "scripts": {
     "lint": "gts lint",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "devDependencies": {
     "lerna": "7.4.2"

--- a/packages/opentelemetry-cloud-monitoring-exporter/package.json
+++ b/packages/opentelemetry-cloud-monitoring-exporter/package.json
@@ -25,7 +25,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opentelemetry-cloud-trace-exporter/package.json
+++ b/packages/opentelemetry-cloud-trace-exporter/package.json
@@ -25,7 +25,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opentelemetry-cloud-trace-propagator/package.json
+++ b/packages/opentelemetry-cloud-trace-propagator/package.json
@@ -24,7 +24,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/opentelemetry-resource-util/package.json
+++ b/packages/opentelemetry-resource-util/package.json
@@ -25,7 +25,7 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "files": [
     "build/src/**/*.js",

--- a/samples/instrumentation-quickstart/package.json
+++ b/samples/instrumentation-quickstart/package.json
@@ -10,6 +10,9 @@
   ],
   "license": "Apache-2.0",
   "keywords": [],
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "gts lint",

--- a/samples/metrics/package.json
+++ b/samples/metrics/package.json
@@ -8,7 +8,7 @@
     "start": "node ./index.js"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "repository": "GoogleCloudPlatform/opentelemetry-operations-js",
   "dependencies": {

--- a/samples/otlpmetricexport/package.json
+++ b/samples/otlpmetricexport/package.json
@@ -14,6 +14,9 @@
     "pretest": "npm run compile"
   },
   "keywords": [],
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/auto-instrumentations-node": "0.50.0",

--- a/samples/otlptraceexport/package.json
+++ b/samples/otlptraceexport/package.json
@@ -17,6 +17,9 @@
     "pretest": "npm run compile"
   },
   "keywords": [],
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/resources": "1.26.0",

--- a/samples/trace/package.json
+++ b/samples/trace/package.json
@@ -8,7 +8,7 @@
     "start": "node ./index.js"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "repository": "GoogleCloudPlatform/opentelemetry-operations-js",
   "dependencies": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -10,5 +10,8 @@
   },
   "author": "Google Inc.",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {}
 }


### PR DESCRIPTION
Unblocks https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/issues/630 and https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/pull/791/

BREAKING CHANGE: removes support for older Node.js versions in `package.json` engines and CI jobs.
