### PR TITLE
deprecate(resource-util): deprecate `GcpDetectorSync` since it has been upstreamed

### DIFF
--- a/packages/opentelemetry-resource-util/src/detector/detector.ts
+++ b/packages/opentelemetry-resource-util/src/detector/detector.ts
@@ -199,8 +199,14 @@ async function makeResource(attrs: GcpResourceAttributes): Promise<Resource> {
 }
 
 /**
- * Google Cloud resource detector which populates attributes based on the environment this
- * process is running in. If not on GCP, returns an empty resource.
+ * @deprecated The resource detector has been moved upstream to
+ * {@link https://www.npmjs.com/package/@opentelemetry/resource-detector-gcp | @opentelemetry/resource-detector-gcp }
+ * and should be used instead.
+ *
+ * Install and import the resource detector from that package instead:
+ * ```js
+ * import {gcpDetector} from '@opentelemetry/resource-detector-gcp';
+ * ```
  */
 export class GcpDetectorSync implements ResourceDetector {
   private async _asyncAttributes(): Promise<Attributes> {


### PR DESCRIPTION

in https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3007. It will be removed in the next major version release.