### PR TITLE
chore: update E2E tests to use centralized async cleanup 0.22.0

### DIFF
--- a/cloudbuild-e2e-cloud-functions-gen2.yaml
+++ b/cloudbuild-e2e-cloud-functions-gen2.yaml
@@ -42,15 +42,20 @@ steps:
   - name: $_TEST_RUNNER_IMAGE
     id: run-tests-cloud-functions
     dir: /
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - cloud-functions-gen2
       - --functionsource=/workspace/e2e-test-server/dist/function-source.zip
       - --runtime=nodejs20
       - --entrypoint=cloudFunctionHandler
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
   _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/cloudbuild-e2e-cloud-run.yaml
+++ b/cloudbuild-e2e-cloud-run.yaml
@@ -25,13 +25,18 @@ steps:
   - name: $_TEST_RUNNER_IMAGE
     id: run-tests-cloud-run
     dir: /
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - cloud-run
       - --image=$_TEST_SERVER_IMAGE
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
   _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/cloudbuild-e2e-gae-standard.yaml
+++ b/cloudbuild-e2e-gae-standard.yaml
@@ -40,14 +40,19 @@ steps:
   - name: $_TEST_RUNNER_IMAGE
     id: run-tests-gae-standard
     dir: /
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - gae-standard
       - --runtime=nodejs22
       - --appsource=/workspace/e2e-test-server/dist/appsource.zip
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
   _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/cloudbuild-e2e-gae.yaml
+++ b/cloudbuild-e2e-gae.yaml
@@ -26,14 +26,19 @@ steps:
   - name: $_TEST_RUNNER_IMAGE
     id: run-tests-gae
     dir: /
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - gae
       - --image=$_TEST_SERVER_IMAGE
       - --runtime=node
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
   _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/cloudbuild-e2e-gce.yaml
+++ b/cloudbuild-e2e-gce.yaml
@@ -26,14 +26,19 @@ steps:
   - name: $_TEST_RUNNER_IMAGE
     id: run-tests-gce
     dir: /
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - gce
       - --image=$_TEST_SERVER_IMAGE
       - --health-check-timeout=8m
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
   _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/cloudbuild-e2e-gke.yaml
+++ b/cloudbuild-e2e-gke.yaml
@@ -25,13 +25,18 @@ steps:
   - name: $_TEST_RUNNER_IMAGE
     id: run-tests-gke
     dir: /
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - gke
       - --image=$_TEST_SERVER_IMAGE
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
   _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup

--- a/cloudbuild-e2e-local.yaml
+++ b/cloudbuild-e2e-local.yaml
@@ -32,14 +32,19 @@ steps:
   - name: $_TEST_RUNNER_IMAGE
     id: run-tests-local
     dir: /
-    env: ["PROJECT_ID=$PROJECT_ID"]
+    env: ["PROJECT_ID=$PROJECT_ID", "TEST_RUN_ID=$BUILD_ID"]
     args:
       - local
       - --image=$_TEST_SERVER_IMAGE
       - --network=cloudbuild
+      - --skip-cleanup
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
   _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}
+
+options:
+  # Notify for Cloud Build async cleanup trigger
+  pubsubTopic: projects/opentelemetry-ops-e2e/topics/e2e-cleanup


### PR DESCRIPTION
Updates E2E test configurations to use the new centralized async cleanup mechanism introduced in e2e-testing 0.22.0. See https://github.com/GoogleCloudPlatform/opentelemetry-operations-e2e-testing/pull/109 for details.