### PR TITLE
fix(e2e): upgrade GAE standard runtime to nodejs22

### DIFF
--- a/cloudbuild-e2e-cloud-functions-gen2.yaml
+++ b/cloudbuild-e2e-cloud-functions-gen2.yaml
@@ -52,5 +52,5 @@ steps:
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
-  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.20.1
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-cloud-run.yaml
+++ b/cloudbuild-e2e-cloud-run.yaml
@@ -33,5 +33,5 @@ steps:
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
-  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.20.1
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gae-standard.yaml
+++ b/cloudbuild-e2e-gae-standard.yaml
@@ -14,7 +14,7 @@
 steps:
   # GAE standard doesn't play nice with lerna monorepos, so bundle in the local dependencies
   # before creating the zip file.
-  - name: node:20-alpine
+  - name: node:22-alpine
     id: build
     script: |
       set -x
@@ -43,11 +43,11 @@ steps:
     env: ["PROJECT_ID=$PROJECT_ID"]
     args:
       - gae-standard
-      - --runtime=nodejs20
+      - --runtime=nodejs22
       - --appsource=/workspace/e2e-test-server/dist/appsource.zip
 
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
-  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.20.1
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gae.yaml
+++ b/cloudbuild-e2e-gae.yaml
@@ -35,5 +35,5 @@ steps:
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
-  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.20.1
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gce.yaml
+++ b/cloudbuild-e2e-gce.yaml
@@ -35,5 +35,5 @@ steps:
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
-  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.20.1
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-gke.yaml
+++ b/cloudbuild-e2e-gke.yaml
@@ -33,5 +33,5 @@ steps:
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
-  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.20.1
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}

--- a/cloudbuild-e2e-local.yaml
+++ b/cloudbuild-e2e-local.yaml
@@ -41,5 +41,5 @@ steps:
 logsBucket: gs://opentelemetry-ops-e2e-cloud-build-logs
 timeout: 20m
 substitutions:
-  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.20.1
+  _TEST_RUNNER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-e2e-testing:0.22.0
   _TEST_SERVER_IMAGE: us-central1-docker.pkg.dev/${PROJECT_ID}/e2e-testing/opentelemetry-operations-js-e2e-test-server:${SHORT_SHA}


### PR DESCRIPTION
Upgrades GAE standard runtime to nodejs22 as nodejs20 is EOL and no longer allowed on GAE Standard. This fixes the pre-existing E2E test failure.