### PR TITLE
feat: add otel scope attributes to trace spans

### DIFF
--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -33,6 +33,8 @@ import {VERSION, OT_VERSION} from './version';
 
 const AGENT_LABEL_KEY = 'g.co/agent';
 const AGENT_LABEL_VALUE = `opentelemetry-js ${OT_VERSION}; google-cloud-trace-exporter ${VERSION}`;
+const OTEL_SCOPE_NAME_KEY = 'otel.scope.name';
+const OTEL_SCOPE_VERSION_KEY = 'otel.scope.version';
 
 export function getReadableSpanTransformer(
   projectId: string,
@@ -45,6 +47,10 @@ export function getReadableSpanTransformer(
       transformAttributes(
         {
           ...span.attributes,
+          [OTEL_SCOPE_NAME_KEY]: span.instrumentationScope.name,
+          ...(span.instrumentationScope.version
+            ? {[OTEL_SCOPE_VERSION_KEY]: span.instrumentationScope.version}
+            : {}),
           [AGENT_LABEL_KEY]: AGENT_LABEL_VALUE,
         },
         stringifyArrayAttributes,

--- a/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
@@ -71,6 +71,16 @@ describe('transform', () => {
               value: `opentelemetry-js ${OT_VERSION}; google-cloud-trace-exporter ${VERSION}`,
             },
           },
+          'otel.scope.name': {
+            stringValue: {
+              value: 'default',
+            },
+          },
+          'otel.scope.version': {
+            stringValue: {
+              value: '0.0.1',
+            },
+          },
           'g.co/r/generic_node/location': {
             stringValue: {
               value: 'global',
@@ -111,6 +121,31 @@ describe('transform', () => {
   it('should transform spans without parent', () => {
     const result = transformer(readableSpan);
     assert.deepStrictEqual(result.parentSpanId, undefined);
+  });
+
+  it('should transform instrumentation scope metadata', () => {
+    readableSpan = {
+      ...readableSpan,
+      instrumentationScope: {
+        name: 'custom-instrumentation',
+        version: '1.2.3',
+      },
+    };
+
+    const result = transformer(readableSpan);
+
+    assert.deepStrictEqual(
+      result.attributes!.attributeMap!['otel.scope.name'],
+      {
+        stringValue: {value: 'custom-instrumentation'},
+      },
+    );
+    assert.deepStrictEqual(
+      result.attributes!.attributeMap!['otel.scope.version'],
+      {
+        stringValue: {value: '1.2.3'},
+      },
+    );
   });
 
   it('should transform remote spans', () => {
@@ -216,8 +251,9 @@ describe('transform', () => {
     readableSpan.attributes.testUnknownType = {message: 'dropped'};
     const result = transformer(readableSpan);
     assert.deepStrictEqual(result.attributes!.droppedAttributesCount, 1);
-    // count of 4 for the g.co/agent attribute + three g.co/r/generic_node/{label} labels
-    assert.strictEqual(Object.keys(result.attributes!.attributeMap!).length, 4);
+    // count of 6 for g.co/agent, two otel.scope attributes, and three
+    // g.co/r/generic_node/{label} labels
+    assert.strictEqual(Object.keys(result.attributes!.attributeMap!).length, 6);
   });
 
   it('should transform links', () => {
@@ -398,6 +434,16 @@ describe('transform', () => {
             value: `opentelemetry-js ${OT_VERSION}; google-cloud-trace-exporter ${VERSION}`,
           },
         },
+        'otel.scope.name': {
+          stringValue: {
+            value: 'default',
+          },
+        },
+        'otel.scope.version': {
+          stringValue: {
+            value: '0.0.1',
+          },
+        },
         'g.co/r/gce_instance/instance_id': {
           stringValue: {
             value: 'foobar.com',
@@ -442,6 +488,16 @@ describe('transform', () => {
         'g.co/agent': {
           stringValue: {
             value: `opentelemetry-js ${OT_VERSION}; google-cloud-trace-exporter ${VERSION}`,
+          },
+        },
+        'otel.scope.name': {
+          stringValue: {
+            value: 'default',
+          },
+        },
+        'otel.scope.version': {
+          stringValue: {
+            value: '0.0.1',
           },
         },
         'g.co/r/generic_node/location': {


### PR DESCRIPTION
## Summary

- Add `otel.scope.name` and `otel.scope.version` attributes when transforming OpenTelemetry spans for Cloud Trace.
- Cover the new instrumentation scope attributes in transform tests and update existing expectations.

Fixes #746.

## Validation

- `npm run test --workspace @google-cloud/opentelemetry-cloud-trace-exporter`
- `npm run lint --workspace @google-cloud/opentelemetry-cloud-trace-exporter` (passes with existing `@ts-expect-error` warnings)