### PR TITLE
fix(resource-util): add otel api peer dependency

### DIFF
--- a/packages/opentelemetry-resource-util/package.json
+++ b/packages/opentelemetry-resource-util/package.json
@@ -62,7 +62,7 @@
     "typescript": "5.0.4"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/resources": "^2.0.0"
   },

--- a/packages/opentelemetry-resource-util/package.json
+++ b/packages/opentelemetry-resource-util/package.json
@@ -62,6 +62,7 @@
     "typescript": "5.0.4"
   },
   "peerDependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/resources": "^2.0.0"
   },


### PR DESCRIPTION
## Summary
- add `@opentelemetry/api` to `@google-cloud/opentelemetry-resource-util` peer dependencies
- keep the existing devDependency for local build and test workflows
- align the package with the other OpenTelemetry packages in this monorepo that already declare `@opentelemetry/api` as a peer dependency

## Why
Issue #729 reports that `@google-cloud/opentelemetry-resource-util` imports `@opentelemetry/api` at runtime but does not declare it as a runtime-facing dependency. In strict package managers such as Yarn PnP, that makes the package unusable unless consumers add a local package extension.

Adding `@opentelemetry/api` as a peer dependency makes the contract explicit for consumers and matches the dependency shape already used by sibling packages in this repository.

## Validation
- `npm test --workspace @google-cloud/opentelemetry-resource-util`
- `npm run lint --workspace @google-cloud/opentelemetry-resource-util`

Closes #729
