### PR TITLE
fix(exporters): respect explicit projectId

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
@@ -105,11 +105,15 @@ export class MetricExporter implements PushMetricExporter {
       ),
     });
 
-    // Start this async process as early as possible. It will be
-    // awaited on the first export because constructors are synchronous
-    this._projectId = this._auth.getProjectId().catch(err => {
-      diag.error(err);
-    });
+    if (options.projectId) {
+      this._projectId = options.projectId;
+    } else {
+      // Start this async process as early as possible. It will be
+      // awaited on the first export because constructors are synchronous
+      this._projectId = this._auth.getProjectId().catch(err => {
+        diag.error(err);
+      });
+    }
   }
 
   /**

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
@@ -20,7 +20,8 @@ import * as sinon from 'sinon';
 import {MetricExporter} from '../src';
 import {ExportResult, ExportResultCode} from '@opentelemetry/core';
 import {emptyResourceMetrics, generateMetricsData} from './util';
-import {Attributes} from '@opentelemetry/api';
+import {Attributes, diag} from '@opentelemetry/api';
+import * as googleAuthLibrary from 'google-auth-library';
 
 import type {monitoring_v3} from 'googleapis';
 import {describe} from 'mocha';
@@ -73,6 +74,51 @@ describe('MetricExporter', () => {
       return (exporter['_projectId'] as Promise<string>).then(id => {
         assert.deepStrictEqual(id, 'not-real');
       });
+    });
+
+    it('should prefer an explicitly configured projectId', async () => {
+      const getProjectIdFake = sinon.fake.resolves('quota-project');
+      class FakeGoogleAuth {
+        getProjectId = getProjectIdFake;
+      }
+      sinon.replaceGetter(
+        googleAuthLibrary,
+        'GoogleAuth',
+        // @ts-expect-error sinon fake
+        () => FakeGoogleAuth,
+      );
+
+      const exporter = new MetricExporter({
+        projectId: 'explicit-project',
+      });
+
+      const id = await exporter['_projectId'];
+      assert.strictEqual(id, 'explicit-project');
+      assert.ok(getProjectIdFake.notCalled);
+    });
+
+    it('should log and return undefined when projectId lookup fails', async () => {
+      delete process.env.GCLOUD_PROJECT;
+      const err = new Error('lookup failed');
+      const getProjectIdFake = sinon.fake.rejects(err);
+      class FakeGoogleAuth {
+        getProjectId = getProjectIdFake;
+      }
+      sinon.replaceGetter(
+        googleAuthLibrary,
+        'GoogleAuth',
+        // @ts-expect-error sinon fake
+        () => FakeGoogleAuth,
+      );
+      const diagError = sinon.stub(diag, 'error');
+
+      const exporter = new MetricExporter();
+
+      const id = await exporter['_projectId'];
+      assert.ok(getProjectIdFake.calledOnce);
+      assert.strictEqual(id, undefined);
+      assert.ok(diagError.calledOnce);
+      assert.strictEqual(diagError.firstCall.args[0], err);
     });
   });
 

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -67,11 +67,15 @@ export class TraceExporter implements SpanExporter {
       scopes: ['https://www.googleapis.com/auth/cloud-platform'],
     });
 
-    // Start this async process as early as possible. It will be
-    // awaited on the first export because constructors are synchronous
-    this._projectId = this._auth.getProjectId().catch(err => {
-      diag.error(err);
-    });
+    if (options.projectId) {
+      this._projectId = options.projectId;
+    } else {
+      // Start this async process as early as possible. It will be
+      // awaited on the first export because constructors are synchronous
+      this._projectId = this._auth.getProjectId().catch(err => {
+        diag.error(err);
+      });
+    }
 
     if (options.apiEndpoint) {
       this._apiEndpoint = options.apiEndpoint;

--- a/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
@@ -60,6 +60,27 @@ describe('Google Cloud Trace Exporter', () => {
       );
     });
 
+    it('should prefer an explicitly configured projectId', async () => {
+      const getProjectIdFake = sinon.fake.resolves('quota-project');
+      class FakeGoogleAuth {
+        getProjectId = getProjectIdFake;
+      }
+      sinon.replaceGetter(
+        googleAuthLibrary,
+        'GoogleAuth',
+        // @ts-expect-error sinon fake
+        () => FakeGoogleAuth,
+      );
+
+      const exporter = new TraceExporter({
+        projectId: 'explicit-project',
+      });
+
+      const id = await exporter['_projectId'];
+      assert.strictEqual(id, 'explicit-project');
+      assert.ok(getProjectIdFake.notCalled);
+    });
+
     it('should construct exporter in GCE/GCP environment without args', async () => {
       delete process.env.GCLOUD_PROJECT;
       const getProjectIdFake = sinon.fake.resolves('fake-project-id');
@@ -78,6 +99,30 @@ describe('Google Cloud Trace Exporter', () => {
       const id = (await exporter['_projectId']) as string;
       assert.ok(getProjectIdFake.calledOnce);
       assert.strictEqual(id, 'fake-project-id');
+    });
+
+    it('should log and return undefined when projectId lookup fails', async () => {
+      delete process.env.GCLOUD_PROJECT;
+      const err = new Error('lookup failed');
+      const getProjectIdFake = sinon.fake.rejects(err);
+      class FakeGoogleAuth {
+        getProjectId = getProjectIdFake;
+      }
+      sinon.replaceGetter(
+        googleAuthLibrary,
+        'GoogleAuth',
+        // @ts-expect-error sinon fake
+        () => FakeGoogleAuth,
+      );
+      const diagError = sinon.stub(diag, 'error');
+
+      const exporter = new TraceExporter();
+
+      const id = await exporter['_projectId'];
+      assert.ok(getProjectIdFake.calledOnce);
+      assert.strictEqual(id, undefined);
+      assert.ok(diagError.calledOnce);
+      assert.strictEqual(diagError.firstCall.args[0], err);
     });
   });
 


### PR DESCRIPTION
## Summary

- preserve an explicitly configured `projectId` in both the trace and monitoring exporters
- fall back to `GoogleAuth.getProjectId()` only when the caller did not provide `projectId`
- cover the explicit-project and lookup-failure paths for both exporters

## Why

Both exporter constructors pass `projectId` to `GoogleAuth`, but then unconditionally replace the exporter field with the result of `getProjectId()`. Retaining the explicit value prevents ambient project discovery from changing the destination project selected by the exporter.

This does not change quota-project handling. The quota project remains credential-driven and is used separately for the `x-goog-user-project` header; this change only controls the project ID used by the exporters for destination resource names.

## Validation

- `npm test --workspace @google-cloud/opentelemetry-cloud-trace-exporter` (30 passing)
- `npm run lint --workspace @google-cloud/opentelemetry-cloud-trace-exporter`
- `npm test --workspace @google-cloud/opentelemetry-cloud-monitoring-exporter` (39 passing)
- `npm run lint --workspace @google-cloud/opentelemetry-cloud-monitoring-exporter`

The trace lint command reports two pre-existing warnings in `test/transform.test.ts`; there are no lint errors.

Closes #794
