### PR TITLE
docs: fix typos in code comments and log message

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
@@ -121,7 +121,7 @@ export class MetricExporter implements PushMetricExporter {
   async forceFlush(): Promise<void> {}
 
   /**
-   * Asnyc wrapper for the {@link export} implementation.
+   * Async wrapper for the {@link export} implementation.
    * Writes the current values of all exported {@link MetricRecord}s
    * to the Google Cloud Monitoring backend.
    *

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/transform.ts
@@ -259,7 +259,7 @@ function transformHistogramValue(
 function transformExponentialHistogramValue(
   value: ExponentialHistogram,
 ): monitoring_v3.Schema$TypedValue {
-  // Adapated from reference impl in Go which has more explanatory comments
+  // Adapted from reference impl in Go which has more explanatory comments
   // https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/v1.8.0/exporter/collector/metrics.go#L582
   const underflow =
     value.zeroCount +

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -149,7 +149,7 @@ export class TraceExporter implements SpanExporter {
     diag.debug('Google Cloud Trace authenticating');
     const creds = await this._auth.getClient();
     diag.debug(
-      'Google Cloud Trace got authentication. Initializaing rpc client',
+      'Google Cloud Trace got authentication. Initializing rpc client',
     );
 
     const packageDefinition = protoloader.fromJSON(protoJson);


### PR DESCRIPTION
Fixes small typos in source comments and one log message:

- `opentelemetry-cloud-monitoring-exporter/src/monitoring.ts`: `Asnyc` → `Async`
- `opentelemetry-cloud-monitoring-exporter/src/transform.ts`: `Adapated` → `Adapted`
- `opentelemetry-cloud-trace-exporter/src/trace.ts`: `Initializaing` → `Initializing` (log message)

No behavior change.