### PR TITLE
docs: update otlp samples to use header provider

### DIFF
--- a/samples/otlptraceexport/src/app-http-json-export.ts
+++ b/samples/otlptraceexport/src/app-http-json-export.ts
@@ -32,12 +32,13 @@ async function getAuthenticatedClient(): Promise<AuthClient> {
 // Express App that exports traces over HTTP with JSON
 async function main() {
   const authenticatedClient = await getAuthenticatedClient();
-  const rawHeaders = await authenticatedClient.getRequestHeaders();
-  const requestHeaders = Object.fromEntries(rawHeaders.entries());
 
   const sdk = new NodeSDK({
     traceExporter: new OTLPTraceExporter({
-      headers: requestHeaders,
+      async headers() {
+        const rawHeaders = await authenticatedClient.getRequestHeaders();
+        return Object.fromEntries(rawHeaders.entries());
+      },
     }),
   });
   sdk.start();

--- a/samples/otlptraceexport/src/app-http-proto-export.ts
+++ b/samples/otlptraceexport/src/app-http-proto-export.ts
@@ -32,12 +32,13 @@ async function getAuthenticatedClient(): Promise<AuthClient> {
 // Express App that exports traces over HTTP with protobuf
 async function main() {
   const authenticatedClient = await getAuthenticatedClient();
-  const rawHeaders = await authenticatedClient.getRequestHeaders();
-  const requestHeaders = Object.fromEntries(rawHeaders.entries());
 
   const sdk = new NodeSDK({
     traceExporter: new OTLPTraceExporter({
-      headers: requestHeaders,
+      async headers() {
+        const rawHeaders = await authenticatedClient.getRequestHeaders();
+        return Object.fromEntries(rawHeaders.entries());
+      },
     }),
   });
   sdk.start();


### PR DESCRIPTION
So that auth refresh happens. This is a new-ish feature for the OTLP exporters from https://github.com/open-telemetry/opentelemetry-js/pull/5994