### PR TITLE
feat: deprecate public symbols in favor of native OTLP endpoints

### DIFF
--- a/packages/opentelemetry-cloud-monitoring-exporter/src/external-types.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/external-types.ts
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @deprecated This interface is deprecated along with the legacy `MetricExporter`.
+ * Please migrate to community-maintained OTLP exporters.
+ */
 export interface ExporterOptions {
   /**
    * Google Cloud Platform project ID where your metrics will be stored.
@@ -64,6 +68,10 @@ export interface ExporterOptions {
   };
 }
 
+/**
+ * @deprecated This interface is deprecated along with the legacy `MetricExporter`.
+ * Please migrate to community-maintained OTLP exporters.
+ */
 export interface Credentials {
   client_email?: string;
   private_key?: string;

--- a/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/src/monitoring.ts
@@ -52,6 +52,13 @@ const OT_REQUEST_HEADER = {
 
 /**
  * Format and sends metrics information to Google Cloud Monitoring.
+ * @deprecated This exporter is deprecated and will be archived after October 30th, 2026.
+ * Please use native OpenTelemetry Protocol (OTLP) endpoints via the Telemetry API and the
+ * community-maintained OTLP exporters instead (e.g., `@opentelemetry/exporter-metrics-otlp-http`
+ * or `@opentelemetry/exporter-metrics-otlp-grpc`).
+ * See the {@link https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/blob/main/MIGRATION.md | Migration Guide}
+ * and {@link https://docs.cloud.google.com/stackdriver/docs/reference/telemetry/overview | Telemetry API documentation}
+ * for more information.
  */
 export class MetricExporter implements PushMetricExporter {
   private _projectId: string | void | Promise<string | void>;
@@ -70,6 +77,12 @@ export class MetricExporter implements PushMetricExporter {
   private _monitoring: monitoring_v3.Monitoring;
 
   constructor(options: ExporterOptions = {}) {
+    process.emitWarning(
+      'Google Cloud OpenTelemetry Monitoring exporter for Node.js is deprecated and will be archived after October 30th, 2026. Please migrate to the OpenTelemetry OTLP exporters. For migration details, see https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/blob/main/MIGRATION.md',
+      'DeprecationWarning',
+      'DEP_GCP_OTEL_MONITORING_EXPORTER',
+      MetricExporter,
+    );
     this._metricPrefix = options.prefix ?? MetricExporter.DEFAULT_METRIC_PREFIX;
     this._disableCreateMetricDescriptors =
       !!options.disableCreateMetricDescriptors;

--- a/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
+++ b/packages/opentelemetry-cloud-monitoring-exporter/test/monitoring.test.ts
@@ -38,6 +38,18 @@ describe('MetricExporter', () => {
   });
 
   describe('constructor', () => {
+    it('should emit a deprecation warning', () => {
+      const emitWarningStub = sinon.stub(process, 'emitWarning');
+      new MetricExporter();
+      sinon.assert.calledWith(
+        emitWarningStub as sinon.SinonSpy,
+        sinon.match(/deprecated and will be archived/),
+        'DeprecationWarning',
+        'DEP_GCP_OTEL_MONITORING_EXPORTER',
+        MetricExporter,
+      );
+    });
+
     it('should construct an exporter', () => {
       const exporter = new MetricExporter();
       assert.ok(typeof exporter.export === 'function');

--- a/packages/opentelemetry-cloud-trace-exporter/src/external-types.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/external-types.ts
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @deprecated This interface is deprecated along with the legacy `TraceExporter`.
+ * Please migrate to community-maintained OTLP exporters.
+ */
 export interface TraceExporterOptions {
   /**
    * Google Cloud Platform project ID where your traces will be stored.
@@ -54,6 +58,10 @@ export interface TraceExporterOptions {
   stringifyArrayAttributes?: boolean;
 }
 
+/**
+ * @deprecated This interface is deprecated along with the legacy `TraceExporter`.
+ * Please migrate to community-maintained OTLP exporters.
+ */
 export interface Credentials {
   client_email?: string;
   private_key?: string;

--- a/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/trace.ts
@@ -33,6 +33,13 @@ const OPTIONS: grpc.ClientOptions = {
 
 /**
  * Format and sends span information to Google Cloud Trace.
+ * @deprecated This exporter is deprecated and will be archived after October 30th, 2026.
+ * Please use native OpenTelemetry Protocol (OTLP) endpoints via the Telemetry API and the
+ * community-maintained OTLP exporters instead (e.g., `@opentelemetry/exporter-trace-otlp-http`
+ * or `@opentelemetry/exporter-trace-otlp-grpc`).
+ * See the {@link https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/blob/main/MIGRATION.md | Migration Guide}
+ * and {@link https://docs.cloud.google.com/stackdriver/docs/instrumentation/migrate-to-otlp-endpoints | Google Cloud documentation}
+ * for more information.
  */
 export class TraceExporter implements SpanExporter {
   private _projectId: string | void | Promise<string | void>;
@@ -43,6 +50,12 @@ export class TraceExporter implements SpanExporter {
   private _apiEndpoint = 'cloudtrace.googleapis.com:443';
 
   constructor(options: TraceExporterOptions = {}) {
+    process.emitWarning(
+      'Google Cloud OpenTelemetry Trace exporter for Node.js is deprecated and will be archived after October 30th, 2026. Please migrate to the OpenTelemetry OTLP exporters. For migration details, see https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/blob/main/MIGRATION.md',
+      'DeprecationWarning',
+      'DEP_GCP_OTEL_TRACE_EXPORTER',
+      TraceExporter,
+    );
     this._resourceFilter = options.resourceFilter;
     this._stringifyArrayAttributes = options.stringifyArrayAttributes ?? false;
 

--- a/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/exporter.test.ts
@@ -48,6 +48,18 @@ describe('Google Cloud Trace Exporter', () => {
       assert.strictEqual(id, 'not-real');
     });
 
+    it('should emit a deprecation warning', () => {
+      const emitWarningStub = sinon.stub(process, 'emitWarning');
+      new TraceExporter();
+      sinon.assert.calledWith(
+        emitWarningStub as sinon.SinonSpy,
+        sinon.match(/deprecated and will be archived/),
+        'DeprecationWarning',
+        'DEP_GCP_OTEL_TRACE_EXPORTER',
+        TraceExporter,
+      );
+    });
+
     it('should construct exporter in GCE/GCP environment without args', async () => {
       delete process.env.GCLOUD_PROJECT;
       const getProjectIdFake = sinon.fake.resolves('fake-project-id');

--- a/packages/opentelemetry-cloud-trace-propagator/package.json
+++ b/packages/opentelemetry-cloud-trace-propagator/package.json
@@ -43,9 +43,11 @@
     "@opentelemetry/core": "2.10.0",
     "@types/mocha": "10.0.10",
     "@types/node": "18.19.130",
+    "@types/sinon": "17.0.4",
     "gts": "6.0.2",
     "mocha": "11.8.0",
     "nyc": "17.1.0",
+    "sinon": "17.0.2",
     "ts-mocha": "11.1.0",
     "typescript": "5.0.4"
   },

--- a/packages/opentelemetry-cloud-trace-propagator/src/CloudPropagator.ts
+++ b/packages/opentelemetry-cloud-trace-propagator/src/CloudPropagator.ts
@@ -38,11 +38,30 @@ import {decToHex, hexToDec} from 'hex2dec';
  *  {TRACE_TRUE} must be 1 to trace request. Specify 0 to not trace the request.
  */
 
-/** Header that carries span context across Google infrastructure. */
+/**
+ * Header that carries span context across Google infrastructure.
+ * @deprecated This header is legacy and discouraged. Standard W3C Trace Context headers
+ * are natively supported by Google Cloud infrastructure.
+ */
 export const X_CLOUD_TRACE_HEADER = 'x-cloud-trace-context';
 const FIELDS = [X_CLOUD_TRACE_HEADER];
 
+/**
+ * @deprecated This propagator is legacy and deprecated and will be archived after October 30th, 2026.
+ * Please use standard W3C Trace Context propagation (e.g., `@opentelemetry/core` `W3CTraceContextPropagator`)
+ * instead. See the {@link https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/blob/main/MIGRATION.md | Migration Guide}
+ * for more information.
+ */
 export class CloudPropagator implements TextMapPropagator {
+  constructor() {
+    process.emitWarning(
+      'Google Cloud OpenTelemetry Trace Propagator for Node.js is deprecated and will be archived after October 30th, 2026. Please migrate to the standard W3C Trace Context propagator. For migration details, see https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/blob/main/MIGRATION.md',
+      'DeprecationWarning',
+      'DEP_GCP_OTEL_TRACE_PROPAGATOR',
+      CloudPropagator,
+    );
+  }
+
   inject(
     context: Context,
     carrier: unknown,

--- a/packages/opentelemetry-cloud-trace-propagator/test/CloudPropagator.test.ts
+++ b/packages/opentelemetry-cloud-trace-propagator/test/CloudPropagator.test.ts
@@ -21,6 +21,7 @@ import {
   TraceFlags,
 } from '@opentelemetry/api';
 import * as assert from 'assert';
+import * as sinon from 'sinon';
 import {CloudPropagator, X_CLOUD_TRACE_HEADER} from '../src/CloudPropagator';
 
 describe('CloudPropagator', () => {
@@ -29,6 +30,24 @@ describe('CloudPropagator', () => {
 
   beforeEach(() => {
     carrier = {};
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('constructor', () => {
+    it('should emit a deprecation warning', () => {
+      const emitWarningStub = sinon.stub(process, 'emitWarning');
+      new CloudPropagator();
+      sinon.assert.calledWith(
+        emitWarningStub as sinon.SinonSpy,
+        sinon.match(/deprecated and will be archived/),
+        'DeprecationWarning',
+        'DEP_GCP_OTEL_TRACE_PROPAGATOR',
+        CloudPropagator,
+      );
+    });
   });
 
   describe('.inject()', () => {

--- a/packages/opentelemetry-resource-util/src/detector/detector.ts
+++ b/packages/opentelemetry-resource-util/src/detector/detector.ts
@@ -199,7 +199,8 @@ async function makeResource(attrs: GcpResourceAttributes): Promise<Resource> {
 }
 
 /**
- * @deprecated The resource detector has been moved upstream to
+ * @deprecated The resource detector is deprecated and will be archived after October 30th, 2026.
+ * It has been moved upstream to
  * {@link https://www.npmjs.com/package/@opentelemetry/resource-detector-gcp | @opentelemetry/resource-detector-gcp }
  * and should be used instead.
  *
@@ -207,8 +208,20 @@ async function makeResource(attrs: GcpResourceAttributes): Promise<Resource> {
  * ```js
  * import {gcpDetector} from '@opentelemetry/resource-detector-gcp';
  * ```
+ *
+ * See the {@link https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/blob/main/MIGRATION.md | Migration Guide}
+ * for more information.
  */
 export class GcpDetectorSync implements ResourceDetector {
+  constructor() {
+    process.emitWarning(
+      'Google Cloud OpenTelemetry Resource Detector (@google-cloud/opentelemetry-resource-util) is deprecated and will be archived after October 30th, 2026. Please migrate to @opentelemetry/resource-detector-gcp. For migration details, see https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/blob/main/MIGRATION.md',
+      'DeprecationWarning',
+      'DEP_GCP_OTEL_RESOURCE_DETECTOR',
+      GcpDetectorSync,
+    );
+  }
+
   private async _asyncAttributes(): Promise<Attributes> {
     return (await detect()).attributes;
   }

--- a/packages/opentelemetry-resource-util/src/index.ts
+++ b/packages/opentelemetry-resource-util/src/index.ts
@@ -213,6 +213,10 @@ type Mapping = {
 };
 
 type Labels = {[key: string]: string};
+/**
+ * @deprecated This interface is deprecated as it is only used by the legacy exporters
+ * in this repository.
+ */
 export interface MonitoredResource {
   type: string;
   labels: Labels;
@@ -222,6 +226,8 @@ export interface MonitoredResource {
  * Given an OTel resource, return a MonitoredResource. Copied from the collector's
  * implementation in Go:
  * https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/v1.8.0/internal/resourcemapping/resourcemapping.go#L51
+ * @deprecated This function is deprecated as it is only used by the legacy exporters
+ * in this repository.
  *
  * @param resource the OTel Resource
  * @returns the corresponding GCM MonitoredResource
@@ -312,4 +318,8 @@ function createMonitoredResource(
   };
 }
 
+/**
+ * @deprecated The resource detector has been moved upstream to `@opentelemetry/resource-detector-gcp`
+ * and should be used instead.
+ */
 export {GcpDetectorSync} from './detector/detector';

--- a/packages/opentelemetry-resource-util/test/detector/detector.test.ts
+++ b/packages/opentelemetry-resource-util/test/detector/detector.test.ts
@@ -44,6 +44,18 @@ describe('GcpDetectorSync', () => {
     sinon.restore();
   });
 
+  it('should emit a deprecation warning', () => {
+    const emitWarningStub = sinon.stub(process, 'emitWarning');
+    new GcpDetectorSync();
+    sinon.assert.calledWith(
+      emitWarningStub as sinon.SinonSpy,
+      sinon.match(/deprecated and will be archived/),
+      'DeprecationWarning',
+      'DEP_GCP_OTEL_RESOURCE_DETECTOR',
+      GcpDetectorSync,
+    );
+  });
+
   it('returns empty resource when metadata server is not available', async () => {
     metadataStub.isAvailable.resolves(false);
     const resource = await detectAndWait(new GcpDetectorSync());


### PR DESCRIPTION
* Annotates exported classes, interfaces, and functions with JSDoc `@deprecated` comments pointing to upstream OpenTelemetry replacements.
* Emit runtime deprecation warnings on exporter initialization

Annotating public symbols with `@deprecated` causes IDEs (such as VSCode and JetBrains) to display strikethroughs and hover warnings on imported symbols, and allows linters (such as `@typescript-eslint/no-deprecated`) to flag deprecated usage during CI builds.