### PR TITLE
fix(trace): export instrumentation scope attributes

### DIFF
--- a/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/src/transform.ts
@@ -33,6 +33,8 @@ import {VERSION, OT_VERSION} from './version';
 
 const AGENT_LABEL_KEY = 'g.co/agent';
 const AGENT_LABEL_VALUE = `opentelemetry-js ${OT_VERSION}; google-cloud-trace-exporter ${VERSION}`;
+const INSTRUMENTATION_SCOPE_NAME_ATTRIBUTE = 'otel.scope.name';
+const INSTRUMENTATION_SCOPE_VERSION_ATTRIBUTE = 'otel.scope.version';
 
 export function getReadableSpanTransformer(
   projectId: string,
@@ -40,15 +42,26 @@ export function getReadableSpanTransformer(
   stringifyArrayAttributes?: boolean,
 ): (span: ReadableSpan) => Span {
   return span => {
+    const spanAttributes: ot.SpanAttributes = {
+      ...span.attributes,
+      [AGENT_LABEL_KEY]: AGENT_LABEL_VALUE,
+    };
+
+    if (spanAttributes[INSTRUMENTATION_SCOPE_NAME_ATTRIBUTE] === undefined) {
+      spanAttributes[INSTRUMENTATION_SCOPE_NAME_ATTRIBUTE] =
+        span.instrumentationScope.name;
+    }
+    if (
+      spanAttributes[INSTRUMENTATION_SCOPE_VERSION_ATTRIBUTE] === undefined &&
+      span.instrumentationScope.version
+    ) {
+      spanAttributes[INSTRUMENTATION_SCOPE_VERSION_ATTRIBUTE] =
+        span.instrumentationScope.version;
+    }
+
     // @todo get dropped attribute count from sdk ReadableSpan
     const attributes = mergeAttributes(
-      transformAttributes(
-        {
-          ...span.attributes,
-          [AGENT_LABEL_KEY]: AGENT_LABEL_VALUE,
-        },
-        stringifyArrayAttributes,
-      ),
+      transformAttributes(spanAttributes, stringifyArrayAttributes),
       // Add in special g.co/r resource labels
       transformResourceToAttributes(
         span.resource,

--- a/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
+++ b/packages/opentelemetry-cloud-trace-exporter/test/transform.test.ts
@@ -71,6 +71,12 @@ describe('transform', () => {
               value: `opentelemetry-js ${OT_VERSION}; google-cloud-trace-exporter ${VERSION}`,
             },
           },
+          'otel.scope.name': {
+            stringValue: {value: 'default'},
+          },
+          'otel.scope.version': {
+            stringValue: {value: '0.0.1'},
+          },
           'g.co/r/generic_node/location': {
             stringValue: {
               value: 'global',
@@ -158,6 +164,42 @@ describe('transform', () => {
     assert.deepStrictEqual(result.attributes!.droppedAttributesCount, 3);
   });
 
+  it('should preserve explicit instrumentation scope attributes', () => {
+    readableSpan.attributes['otel.scope.name'] = 'custom-name';
+    readableSpan.attributes['otel.scope.version'] = 'custom-version';
+
+    const result = transformer(readableSpan);
+
+    assert.deepStrictEqual(
+      result.attributes!.attributeMap!['otel.scope.name'],
+      {
+        stringValue: {value: 'custom-name'},
+      },
+    );
+    assert.deepStrictEqual(
+      result.attributes!.attributeMap!['otel.scope.version'],
+      {stringValue: {value: 'custom-version'}},
+    );
+  });
+
+  it('should omit an empty instrumentation scope version', () => {
+    readableSpan = {
+      ...readableSpan,
+      instrumentationScope: {name: 'default'},
+    };
+
+    const result = transformer(readableSpan);
+
+    assert.deepStrictEqual(
+      result.attributes!.attributeMap!['otel.scope.name'],
+      {stringValue: {value: 'default'}},
+    );
+    assert.strictEqual(
+      result.attributes!.attributeMap!['otel.scope.version'],
+      undefined,
+    );
+  });
+
   it('should transform attributes while stringifying arrays', () => {
     readableSpan.attributes.testBool = true;
     readableSpan.attributes.testInt = 3;
@@ -216,8 +258,8 @@ describe('transform', () => {
     readableSpan.attributes.testUnknownType = {message: 'dropped'};
     const result = transformer(readableSpan);
     assert.deepStrictEqual(result.attributes!.droppedAttributesCount, 1);
-    // count of 4 for the g.co/agent attribute + three g.co/r/generic_node/{label} labels
-    assert.strictEqual(Object.keys(result.attributes!.attributeMap!).length, 4);
+    // count of 6 for the agent and scope attributes + three g.co/r/generic_node/{label} labels
+    assert.strictEqual(Object.keys(result.attributes!.attributeMap!).length, 6);
   });
 
   it('should transform links', () => {
@@ -398,6 +440,12 @@ describe('transform', () => {
             value: `opentelemetry-js ${OT_VERSION}; google-cloud-trace-exporter ${VERSION}`,
           },
         },
+        'otel.scope.name': {
+          stringValue: {value: 'default'},
+        },
+        'otel.scope.version': {
+          stringValue: {value: '0.0.1'},
+        },
         'g.co/r/gce_instance/instance_id': {
           stringValue: {
             value: 'foobar.com',
@@ -443,6 +491,12 @@ describe('transform', () => {
           stringValue: {
             value: `opentelemetry-js ${OT_VERSION}; google-cloud-trace-exporter ${VERSION}`,
           },
+        },
+        'otel.scope.name': {
+          stringValue: {value: 'default'},
+        },
+        'otel.scope.version': {
+          stringValue: {value: '0.0.1'},
         },
         'g.co/r/generic_node/location': {
           stringValue: {


### PR DESCRIPTION
## Summary

- export instrumentation scope name and version as `otel.scope.name` and `otel.scope.version`
- preserve explicitly supplied span attributes and omit the version attribute when the scope has no version
- add regression coverage for the exported values, precedence, and missing-version behavior

## Validation

- `npm test`
- `npm run lint`
- `git diff --check`

Fixes #746
